### PR TITLE
VFP: Fixed the VCVT behavior when converting from unsigned 32-bit values

### DIFF
--- a/src/backend_x64/emit_x64.cpp
+++ b/src/backend_x64/emit_x64.cpp
@@ -1949,9 +1949,10 @@ void EmitX64::EmitFPU32ToSingle(IR::Block& block, IR::Inst* inst) {
 
     Xbyak::Xmm from = reg_alloc.UseXmm(a);
     Xbyak::Xmm to = reg_alloc.DefXmm(inst);
-    Xbyak::Reg32 gpr_scratch = reg_alloc.ScratchGpr().cvt32();
+    // Use a 64-bit register to ensure we don't end up treating the input as signed
+    Xbyak::Reg64 gpr_scratch = reg_alloc.ScratchGpr();
 
-    code->movd(gpr_scratch, from);
+    code->movq(gpr_scratch, from);
     code->cvtsi2ss(to, gpr_scratch);
 }
 
@@ -1975,9 +1976,10 @@ void EmitX64::EmitFPU32ToDouble(IR::Block& block, IR::Inst* inst) {
 
     Xbyak::Xmm from = reg_alloc.UseXmm(a);
     Xbyak::Xmm to = reg_alloc.DefXmm(inst);
-    Xbyak::Reg32 gpr_scratch = reg_alloc.ScratchGpr().cvt32();
+    // Use a 64-bit register to ensure we don't end up treating the input as signed
+    Xbyak::Reg64 gpr_scratch = reg_alloc.ScratchGpr();
 
-    code->movd(gpr_scratch, from);
+    code->movq(gpr_scratch, from);
     code->cvtsi2sd(to, gpr_scratch);
 }
 


### PR DESCRIPTION
Use a 64-bit register to hold the values so that we don't end up interpreting them as signed values.