### PR TITLE
[RFC] coprocessor_util: Expose coprocessor decoding functions for library users

### DIFF
--- a/include/dynarmic/coprocessor_util.h
+++ b/include/dynarmic/coprocessor_util.h
@@ -1,0 +1,40 @@
+/* This file is part of the dynarmic project.
+ * Copyright (c) 2016 MerryMage
+ * This software may be used and distributed according to the terms of the GNU
+ * General Public License version 2 or any later version.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+#include <functional>
+
+namespace Dynarmic {
+namespace Coprocessor {
+
+enum class ArmReg {
+    R0, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15,
+    SP = R13,
+    LR = R14,
+    PC = R15
+};
+
+enum class CoprocReg {
+    C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15
+};
+
+enum class Coprocessor {
+    P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15
+};
+
+void DecodeCDP(std::uint32_t instruction, std::function<void(bool two, std::size_t opc1, CoprocReg CRn, CoprocReg CRd, Coprocessor coproc, std::size_t opc2, CoprocReg CRm)> callback);
+void DecodeLDC(std::uint32_t instruction, std::function<void(bool two, bool p, bool u, bool d, bool w, ArmReg n, CoprocReg CRd, Coprocessor coproc, std::uint8_t imm8)> callback);
+void DecodeSTC(std::uint32_t instruction, std::function<void(bool two, bool p, bool u, bool d, bool w, ArmReg n, CoprocReg CRd, Coprocessor coproc, std::uint8_t imm8)> callback);
+void DecodeMCR(std::uint32_t instruction, std::function<void(bool two, std::size_t opc1, CoprocReg CRn, ArmReg t, Coprocessor coproc, std::size_t opc2, CoprocReg CRm)> callback);
+void DecodeMCRR(std::uint32_t instruction, std::function<void(bool two, ArmReg t2, ArmReg t, Coprocessor coproc, std::size_t opc, CoprocReg CRm)> callback);
+void DecodeMRC(std::uint32_t instruction, std::function<void(bool two, std::size_t opc1, CoprocReg CRn, ArmReg t, Coprocessor coproc, std::size_t opc2, CoprocReg CRm)> callback);
+void DecodeMRRC(std::uint32_t instruction, std::function<void(bool two, ArmReg t2, ArmReg t, Coprocessor coproc, std::size_t opc, CoprocReg CRm)> callback);
+
+} // namespace Coprocessor
+} // namespace Dynarmic

--- a/src/frontend/decoder/coprocessor.cpp
+++ b/src/frontend/decoder/coprocessor.cpp
@@ -1,0 +1,80 @@
+/* This file is part of the dynarmic project.
+ * Copyright (c) 2016 MerryMage
+ * This software may be used and distributed according to the terms of the GNU
+ * General Public License version 2 or any later version.
+ */
+
+#include "common/common_types.h"
+#include "frontend/arm/types.h"
+#include "frontend/decoder/coprocessor.h"
+#include "frontend/decoder/decoder_detail.h"
+#include "frontend/decoder/matcher.h"
+
+namespace Dynarmic {
+namespace Coprocessor {
+
+template <typename T>
+auto GetMemberFunctionOfLambda(T) {
+    return &T::operator();
+}
+
+#define MAKE_MATCHER(name, bitstring) (Arm::detail::detail<Arm::Matcher<decltype(visitor), u32>>::GetMatcher(GetMemberFunctionOfLambda(visitor), name, bitstring))
+
+void DecodeCDP(u32 instruction, std::function<void(bool two, size_t opc1, CoprocReg CRn, CoprocReg CRd, Coprocessor coproc, size_t opc2, CoprocReg CRm)> callback) {
+    auto visitor = [&](Arm::Cond cond, size_t opc1, CoprocReg CRn, CoprocReg CRd, Coprocessor coproc, size_t opc2, CoprocReg CRm) {
+        callback(cond == Arm::Cond::NV, opc1, CRn, CRd, coproc, opc2, CRm);
+    };
+    const static auto matcher = MAKE_MATCHER("CDP", "cccc1110ooooNNNNDDDDppppooo0MMMM");
+    matcher.call(visitor, instruction);
+}
+
+void DecodeLDC(u32 instruction, std::function<void(bool two, bool p, bool u, bool d, bool w, ArmReg n, CoprocReg CRd, Coprocessor coproc, u8 imm8)> callback) {
+    auto visitor = [&](Arm::Cond cond, bool p, bool u, bool d, bool w, ArmReg n, CoprocReg CRd, Coprocessor coproc, u8 imm8) {
+        callback(cond == Arm::Cond::NV, p, u, d, w, n, CRd, coproc, imm8);
+    };
+    const static auto matcher = MAKE_MATCHER("LDC", "cccc110pudw1nnnnDDDDppppvvvvvvvv");
+    matcher.call(visitor, instruction);
+}
+
+void DecodeSTC(u32 instruction, std::function<void(bool two, bool p, bool u, bool d, bool w, ArmReg n, CoprocReg CRd, Coprocessor coproc, u8 imm8)> callback) {
+    auto visitor = [&](Arm::Cond cond, bool p, bool u, bool d, bool w, ArmReg n, CoprocReg CRd, Coprocessor coproc, u8 imm8) {
+        callback(cond == Arm::Cond::NV, p, u, d, w, n, CRd, coproc, imm8);
+    };
+    const static auto matcher = MAKE_MATCHER("STC", "cccc110pudw0nnnnDDDDppppvvvvvvvv");
+    matcher.call(visitor, instruction);
+}
+
+void DecodeMCR(u32 instruction, std::function<void(bool two, size_t opc1, CoprocReg CRn, ArmReg t, Coprocessor coproc, size_t opc2, CoprocReg CRm)> callback) {
+    auto visitor = [&](Arm::Cond cond, size_t opc1, CoprocReg CRn, ArmReg t, Coprocessor coproc, size_t opc2, CoprocReg CRm) {
+        callback(cond == Arm::Cond::NV, opc1, CRn, t, coproc, opc2, CRm);
+    };
+    const static auto matcher = MAKE_MATCHER("MCR", "cccc1110ooo0NNNNttttppppooo1MMMM");
+    matcher.call(visitor, instruction);
+}
+
+void DecodeMCRR(u32 instruction, std::function<void(bool two, ArmReg t2, ArmReg t, Coprocessor coproc, size_t opc, CoprocReg CRm)> callback) {
+    auto visitor = [&](Arm::Cond cond, ArmReg t2, ArmReg t, Coprocessor coproc, size_t opc, CoprocReg CRm) {
+        callback(cond == Arm::Cond::NV, t2, t, coproc, opc, CRm);
+    };
+    const static auto matcher = MAKE_MATCHER("MCRR", "cccc11000100uuuuttttppppooooMMMM");
+    matcher.call(visitor, instruction);
+}
+
+void DecodeMRC(u32 instruction, std::function<void(bool two, size_t opc1, CoprocReg CRn, ArmReg t, Coprocessor coproc, size_t opc2, CoprocReg CRm)> callback) {
+    auto visitor = [&](Arm::Cond cond, size_t opc1, CoprocReg CRn, ArmReg t, Coprocessor coproc, size_t opc2, CoprocReg CRm) {
+        callback(cond == Arm::Cond::NV, opc1, CRn, t, coproc, opc2, CRm);
+    };
+    const static auto matcher = MAKE_MATCHER("MRC", "cccc1110ooo1NNNNttttppppooo1MMMM");
+    matcher.call(visitor, instruction);
+}
+
+void DecodeMRRC(u32 instruction, std::function<void(bool two, ArmReg t2, ArmReg t, Coprocessor coproc, size_t opc, CoprocReg CRm)> callback) {
+    auto visitor = [&](Arm::Cond cond, ArmReg t2, ArmReg t, Coprocessor coproc, size_t opc, CoprocReg CRm) {
+        callback(cond == Arm::Cond::NV, t2, t, coproc, opc, CRm);
+    };
+    const static auto matcher = MAKE_MATCHER("MRRC", "cccc11000101uuuuttttppppooooMMMM");
+    matcher.call(visitor, instruction);
+}
+
+} // namespace Coprocessor
+} // namespace Dynarmic

--- a/src/frontend/decoder/coprocessor.h
+++ b/src/frontend/decoder/coprocessor.h
@@ -1,0 +1,9 @@
+/* This file is part of the dynarmic project.
+ * Copyright (c) 2016 MerryMage
+ * This software may be used and distributed according to the terms of the GNU
+ * General Public License version 2 or any later version.
+ */
+
+#pragma once
+
+#include <dynarmic/coprocessor_util.h>


### PR DESCRIPTION
Not too happy with this.

Would probably be useful for library users; though need it even be done? i.e.: Someone who write a coprocessor could probably do decoding themselves.