### PR TITLE
Ranged cache invalidation

### DIFF
--- a/include/dynarmic/dynarmic.h
+++ b/include/dynarmic/dynarmic.h
@@ -8,8 +8,8 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <string>
 #include <memory>
+#include <string>
 
 #include <dynarmic/callbacks.h>
 
@@ -37,6 +37,13 @@ public:
      * Can be called at any time. Halts execution if called within a callback.
      */
     void ClearCache();
+
+    /**
+     * Invalidate the code cache at a range of addresses.
+     * @param start_address The starting address of the range to invalidate.
+     * @param length The length (in bytes) of the range to invalidate.
+     */
+    void InvalidateCacheRange(std::uint32_t start_address, std::size_t length);
 
     /**
      * Reset CPU state to state at startup. Does not clear code cache.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,7 @@ set(HEADERS
     ../include/dynarmic/coprocessor_util.h
     ../include/dynarmic/disassembler.h
     ../include/dynarmic/dynarmic.h
+    common/address_range.h
     common/assert.h
     common/bit_util.h
     common/common_types.h

--- a/src/backend_x64/emit_x64.cpp
+++ b/src/backend_x64/emit_x64.cpp
@@ -12,8 +12,10 @@
 #include "backend_x64/block_of_code.h"
 #include "backend_x64/emit_x64.h"
 #include "backend_x64/jitstate.h"
+#include "common/address_range.h"
 #include "common/assert.h"
 #include "common/bit_util.h"
+#include "common/common_types.h"
 #include "common/variant_util.h"
 #include "frontend/arm/types.h"
 #include "frontend/ir/basic_block.h"
@@ -61,8 +63,9 @@ EmitX64::EmitX64(BlockOfCode* code, UserCallbacks cb, Jit* jit_interface)
 
 EmitX64::BlockDescriptor EmitX64::Emit(IR::Block& block) {
     code->align();
-    const u8* const emitted_code_start_ptr = code->getCurr();
+    const u8* const entrypoint = code->getCurr();
 
+    // Start emitting.
     EmitCondPrelude(block);
 
     RegAlloc reg_alloc{code};
@@ -95,11 +98,12 @@ EmitX64::BlockDescriptor EmitX64::Emit(IR::Block& block) {
     code->int3();
 
     const IR::LocationDescriptor descriptor = block.Location();
-    Patch(descriptor, emitted_code_start_ptr);
+    Patch(descriptor, entrypoint);
 
-    EmitX64::BlockDescriptor& block_desc = block_descriptors[descriptor.UniqueHash()];
-    size_t emitted_code_size = static_cast<size_t>(code->getCurr() - emitted_code_start_ptr);
-    block_desc = {emitted_code_start_ptr, emitted_code_size};
+    const size_t size = static_cast<size_t>(code->getCurr() - entrypoint);
+    EmitX64::BlockDescriptor block_desc{entrypoint, size, block.Location(), block.EndLocation().PC()};
+    block_descriptors.emplace(descriptor.UniqueHash(), block_desc);
+
     return block_desc;
 }
 
@@ -446,7 +450,7 @@ void EmitX64::EmitPushRSB(RegAlloc& reg_alloc, IR::Block&, IR::Inst* inst) {
 
     auto iter = block_descriptors.find(unique_hash_of_target);
     CodePtr target_code_ptr = iter != block_descriptors.end()
-                            ? iter->second.code_ptr
+                            ? iter->second.entrypoint
                             : code->GetReturnFromRunCodeAddress();
 
     Xbyak::Reg64 code_ptr_reg = reg_alloc.ScratchGpr({HostLoc::RCX});
@@ -3332,7 +3336,7 @@ void EmitX64::EmitTerminal(IR::Term::LinkBlock terminal, IR::LocationDescriptor 
 
     patch_information[terminal.next.UniqueHash()].jg.emplace_back(code->getCurr());
     if (auto next_bb = GetBasicBlock(terminal.next)) {
-        EmitPatchJg(next_bb->code_ptr);
+        EmitPatchJg(next_bb->entrypoint);
     } else {
         EmitPatchJg();
     }
@@ -3361,7 +3365,7 @@ void EmitX64::EmitTerminal(IR::Term::LinkBlockFast terminal, IR::LocationDescrip
 
     patch_information[terminal.next.UniqueHash()].jmp.emplace_back(code->getCurr());
     if (auto next_bb = GetBasicBlock(terminal.next)) {
-        EmitPatchJmp(terminal.next, next_bb->code_ptr);
+        EmitPatchJmp(terminal.next, next_bb->entrypoint);
     } else {
         EmitPatchJmp(terminal.next);
     }
@@ -3460,6 +3464,35 @@ void EmitX64::EmitPatchMovRcx(CodePtr target_code_ptr) {
 void EmitX64::ClearCache() {
     block_descriptors.clear();
     patch_information.clear();
+}
+
+void EmitX64::InvalidateCacheRange(const Common::AddressRange& range) {
+    // Remove cached block descriptors and patch information overlapping with the given range.
+
+    switch (range.which()) {
+    case 0: // FullAddressRange
+        ClearCache();
+        break;
+
+    case 1: // AddressInterval
+        auto interval = boost::get<Common::AddressInterval>(range);
+        for (auto it = std::begin(block_descriptors); it != std::end(block_descriptors);) {
+            const IR::LocationDescriptor& descriptor = it->second.start_location;
+            u32 start = descriptor.PC();
+            u32 end = it->second.end_location_pc;
+            if (interval.Overlaps(start, end)) {
+                it = block_descriptors.erase(it);
+
+                auto patch_it = patch_information.find(descriptor.UniqueHash());
+                if (patch_it != patch_information.end()) {
+                    Unpatch(descriptor);
+                }
+            } else {
+                ++it;
+            }
+        }
+        break;
+    }
 }
 
 } // namespace BackendX64

--- a/src/backend_x64/emit_x64.h
+++ b/src/backend_x64/emit_x64.h
@@ -14,6 +14,7 @@
 #include <xbyak_util.h>
 
 #include "backend_x64/reg_alloc.h"
+#include "common/address_range.h"
 #include "dynarmic/callbacks.h"
 #include "frontend/ir/location_descriptor.h"
 #include "frontend/ir/terminal.h"
@@ -34,8 +35,11 @@ class BlockOfCode;
 class EmitX64 final {
 public:
     struct BlockDescriptor {
-        CodePtr code_ptr; ///< Entrypoint of emitted code
-        size_t size;      ///< Length in bytes of emitted code
+        CodePtr entrypoint;  // Entrypoint of emitted code
+        size_t size;         // Length in bytes of emitted code
+
+        IR::LocationDescriptor start_location;
+        u32 end_location_pc;
     };
 
     EmitX64(BlockOfCode* code, UserCallbacks cb, Jit* jit_interface);
@@ -49,8 +53,15 @@ public:
     /// Looks up an emitted host block in the cache.
     boost::optional<BlockDescriptor> GetBasicBlock(IR::LocationDescriptor descriptor) const;
 
-    /// Empties the cache.
+    /// Empties the entire cache.
     void ClearCache();
+
+    /**
+     * Invalidate the cache at a range of addresses.
+     * @param start_address The starting address of the range to invalidate.
+     * @param length The length (in bytes) of the range to invalidate.
+     */
+    void InvalidateCacheRange(const Common::AddressRange& range);
 
 private:
     // Microinstruction emitters

--- a/src/common/address_range.h
+++ b/src/common/address_range.h
@@ -1,0 +1,33 @@
+/* This file is part of the dynarmic project.
+ * Copyright (c) 2016 MerryMage
+ * This software may be used and distributed according to the terms of the GNU
+ * General Public License version 2 or any later version.
+ */
+
+#pragma once
+
+#include <cstddef>
+
+#include <boost/variant.hpp>
+
+#include "common/common_types.h"
+
+namespace Dynarmic {
+namespace Common {
+
+struct FullAddressRange {};
+
+struct AddressInterval {
+    u32 start_address;
+    std::size_t length;
+
+    // Does this interval overlap with [from, to)?
+    bool Overlaps(u32 from, u32 to) const {
+        return start_address <= to && from <= start_address + length;
+    }
+};
+
+using AddressRange = boost::variant<FullAddressRange, AddressInterval>;
+
+} // namespace Common
+} // namespace Dynarmic

--- a/src/frontend/ir/basic_block.cpp
+++ b/src/frontend/ir/basic_block.cpp
@@ -35,6 +35,14 @@ LocationDescriptor Block::Location() const {
     return location;
 }
 
+LocationDescriptor Block::EndLocation() const {
+    return end_location;
+}
+
+void Block::SetEndLocation(const LocationDescriptor& descriptor) {
+    end_location = descriptor;
+}
+
 Arm::Cond Block::GetCondition() const {
     return cond;
 }

--- a/src/frontend/ir/basic_block.h
+++ b/src/frontend/ir/basic_block.h
@@ -40,7 +40,8 @@ public:
     using reverse_iterator       = InstructionList::reverse_iterator;
     using const_reverse_iterator = InstructionList::const_reverse_iterator;
 
-    explicit Block(const LocationDescriptor& location) : location(location) {}
+    explicit Block(const LocationDescriptor& location)
+        : location(location), end_location(location) {}
 
     bool                   empty()   const { return instructions.empty();   }
     size_type              size()    const { return instructions.size();    }
@@ -78,6 +79,10 @@ public:
 
     /// Gets the starting location for this basic block.
     LocationDescriptor Location() const;
+    /// Gets the end location for this basic block.
+    LocationDescriptor EndLocation() const;
+    /// Sets the end location for this basic block.
+    void SetEndLocation(const LocationDescriptor& descriptor);
 
     /// Gets the condition required to pass in order to execute this block.
     Arm::Cond GetCondition() const;
@@ -116,6 +121,8 @@ public:
 private:
     /// Description of the starting location of this block
     LocationDescriptor location;
+    /// Description of the end location of this block
+    LocationDescriptor end_location;
     /// Conditional to pass in order to execute this block
     Arm::Cond cond = Arm::Cond::AL;
     /// Block to execute next if `cond` did not pass.

--- a/src/frontend/translate/translate_arm.cpp
+++ b/src/frontend/translate/translate_arm.cpp
@@ -60,6 +60,8 @@ IR::Block TranslateArm(IR::LocationDescriptor descriptor, MemoryReadCodeFuncType
 
     ASSERT_MSG(visitor.ir.block.HasTerminal(), "Terminal has not been set");
 
+    visitor.ir.block.SetEndLocation(visitor.ir.current_location);
+
     return std::move(visitor.ir.block);
 }
 

--- a/src/frontend/translate/translate_thumb.cpp
+++ b/src/frontend/translate/translate_thumb.cpp
@@ -909,6 +909,8 @@ IR::Block TranslateThumb(IR::LocationDescriptor descriptor, MemoryReadCodeFuncTy
         visitor.ir.block.CycleCount()++;
     }
 
+    visitor.ir.block.SetEndLocation(visitor.ir.current_location);
+
     return std::move(visitor.ir.block);
 }
 


### PR DESCRIPTION
This implements `EmitX64::InvalidateCacheRange`, which invalidates the cache range passed to it. `Jit::Impl` tracks a queue of ranges to invalidate, instead of a single boolean `clear_cache_required`.

Also, I renamed `code_ptr` in `BlockDescriptor` to `entrypoint` ~~to make this PR harder to merge~~ for readability.