### PR TITLE
Link against static fmtlib when DYNARMIC_NO_BUNDLED_FMT is set

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,7 +115,7 @@ target_compile_options(dynarmic PRIVATE ${DYNARMIC_CXX_FLAGS})
 target_link_libraries(dynarmic
     PRIVATE
         boost
-        fmt-header-only
+        fmt
         xbyak
         $<$<BOOL:DYNARMIC_USE_LLVM>:${llvm_libs}>
 )


### PR DESCRIPTION
When including fmtlib as a header only library in dynarmic, downstream
projects cannot include fmtlib as a static library without getting
linker errors. This change make dynarmic use the static library version
of fmtlib when DYNARMIC_NO_BUNDLED_FMT is set