### PR TITLE
A64: The A64SetTPIDR IR instruction writes to a system register and should not be eliminated by the dead code elimination pass.

### DIFF
--- a/src/frontend/ir/microinstruction.cpp
+++ b/src/frontend/ir/microinstruction.cpp
@@ -152,6 +152,15 @@ bool Inst::WritesToCPSR() const {
     }
 }
 
+bool Inst::WritesToSystemRegister() const {
+    switch (op) {
+    case Opcode::A64SetTPIDR:
+        return true;
+    default:
+        return false;
+    }
+}
+
 bool Inst::ReadsFromCoreRegister() const {
     switch (op) {
     case Opcode::A32GetRegister:
@@ -287,6 +296,7 @@ bool Inst::MayHaveSideEffects() const {
            op == Opcode::A64DataMemoryBarrier           ||
            CausesCPUException()                         ||
            WritesToCoreRegister()                       ||
+           WritesToSystemRegister()                     ||
            WritesToCPSR()                               ||
            WritesToFPSCR()                              ||
            AltersExclusiveState()                       ||

--- a/src/frontend/ir/microinstruction.h
+++ b/src/frontend/ir/microinstruction.h
@@ -55,6 +55,9 @@ public:
     /// Determines whether or not this instruction writes to the CPSR.
     bool WritesToCPSR() const;
 
+    /// Determines whether or not this instruction writes to a system register.
+    bool WritesToSystemRegister() const;
+
     /// Determines whether or not this instruction reads from a core register.
     bool ReadsFromCoreRegister() const;
     /// Determines whether or not this instruction writes to a core register.


### PR DESCRIPTION
Previously this instruction was always eliminated, resulting in incorrect values for TPIDR_EL0.