### PR TITLE
value: Move ImmediateToU64() to be a part of Value's interface

### DIFF
--- a/src/frontend/ir/value.cpp
+++ b/src/frontend/ir/value.cpp
@@ -155,4 +155,23 @@ Cond Value::GetCond() const {
     return inner.imm_cond;
 }
 
+u64 Value::GetImmediateAsU64() const {
+    ASSERT(IsImmediate());
+
+    switch (GetType()) {
+    case IR::Type::U1:
+        return u64(GetU1());
+    case IR::Type::U8:
+        return u64(GetU8());
+    case IR::Type::U16:
+        return u64(GetU16());
+    case IR::Type::U32:
+        return u64(GetU32());
+    case IR::Type::U64:
+        return u64(GetU64());
+    default:
+        ASSERT_MSG(false, "GetImmediateAsU64 called on an incompatible Value type.");
+    }
+}
+
 } // namespace Dynarmic::IR

--- a/src/frontend/ir/value.h
+++ b/src/frontend/ir/value.h
@@ -66,6 +66,14 @@ public:
     CoprocessorInfo GetCoprocInfo() const;
     Cond GetCond() const;
 
+    /**
+     * Retrieves the immediate of a Value instance.
+     *
+     * @pre The value contains either a U1, U8, U16, U32, or U64 value.
+     *      Breaking this precondition will cause an assertion to be invoked.
+     */
+    u64 GetImmediateAsU64() const;
+
 private:
     Type type;
 


### PR DESCRIPTION
This'll make it slightly nicer to do basic constant folding for 32-bit and 64-bit variants of the same IR opcode type. By that, I mean it's possible to inspect immediate values without a bunch of conditional checks beforehand to verify that it's possible to call GetU32() or GetU64, preventing code duplication.