### PR TITLE
Fix Building on Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
-cmake_minimum_required(VERSION 3.8)
+# Android studio currently ships with CMake 3.6
+if(ANDROID)
+    cmake_minimum_required(VERSION 3.6)
+else()
+    cmake_minimum_required(VERSION 3.8)
+endif()
 project(dynarmic CXX)
 
 # Determine if we're built as a subproject (using add_subdirectory)
@@ -21,10 +26,12 @@ if (NOT CMAKE_BUILD_TYPE)
     message(STATUS "Defaulting to a Release build")
 endif()
 
+if(NOT ANDROID)
 # Set hard requirements for C++
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
 
 # Warn on CMake API deprecations
 set(CMAKE_WARN_DEPRECATED ON)
@@ -80,6 +87,11 @@ else()
         -pedantic-errors
         -Wfatal-errors
         -Wno-missing-braces)
+
+    if(ANDROID)
+        list(APPEND DYNARMIC_CXX_FLAGS
+                -std=c++17)
+    endif()
 
     if (DYNARMIC_WARNINGS_AS_ERRORS)
         list(APPEND DYNARMIC_CXX_FLAGS

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -253,7 +253,7 @@ if (ARCHITECTURE_x86_64)
     else()
         target_sources(dynarmic PRIVATE backend/x64/exception_handler_generic.cpp)
     endif()
-elseif(ARCHITECTURE_Aarch64)
+elseif(ARCHITECTURE_Aarch64 OR ARCHITECTURE_ARM64)
     target_sources(dynarmic PRIVATE
          backend/A64/emitter/a64_emitter.cpp
          backend/A64/emitter/a64_emitter.h

--- a/src/backend/x64/a64_emit_x64.cpp
+++ b/src/backend/x64/a64_emit_x64.cpp
@@ -636,9 +636,9 @@ void A64EmitX64::EmitA64SetExclusive(A64EmitContext& ctx, IR::Inst* inst) {
 }
 
 static Xbyak::RegExp EmitVAddrLookup(BlockOfCode& code, A64EmitContext& ctx, Xbyak::Label& abort, Xbyak::Reg64 vaddr, boost::optional<Xbyak::Reg64> arg_scratch = {}) {
-    constexpr size_t PAGE_BITS = 12;
-    constexpr size_t PAGE_SIZE = 1 << PAGE_BITS;
-    const size_t valid_page_index_bits = ctx.conf.page_table_address_space_bits - PAGE_BITS;
+    constexpr size_t page_bits = 12;
+    constexpr size_t page_size = 1 << page_bits;
+    const size_t valid_page_index_bits = ctx.conf.page_table_address_space_bits - page_bits;
     const size_t unused_top_bits = 64 - ctx.conf.page_table_address_space_bits;
 
     Xbyak::Reg64 page_table = arg_scratch.value_or_eval([&]{ return ctx.reg_alloc.ScratchGpr(); });
@@ -646,18 +646,18 @@ static Xbyak::RegExp EmitVAddrLookup(BlockOfCode& code, A64EmitContext& ctx, Xby
     code.mov(page_table, reinterpret_cast<u64>(ctx.conf.page_table));
     code.mov(tmp, vaddr);
     if (unused_top_bits == 0) {
-        code.shr(tmp, int(PAGE_BITS));
+        code.shr(tmp, int(page_bits));
     } else if (ctx.conf.silently_mirror_page_table) {
         if (valid_page_index_bits >= 32) {
             code.shl(tmp, int(unused_top_bits));
-            code.shr(tmp, int(unused_top_bits + PAGE_BITS));
+            code.shr(tmp, int(unused_top_bits + page_bits));
         } else {
-            code.shr(tmp, int(PAGE_BITS));
+            code.shr(tmp, int(page_bits));
             code.and_(tmp, u32((1 << valid_page_index_bits) - 1));
         }
     } else {
         ASSERT(valid_page_index_bits < 32);
-        code.shr(tmp, int(PAGE_BITS));
+        code.shr(tmp, int(page_bits));
         code.test(tmp, u32(-(1 << valid_page_index_bits)));
         code.jnz(abort, code.T_NEAR);
     }
@@ -665,7 +665,7 @@ static Xbyak::RegExp EmitVAddrLookup(BlockOfCode& code, A64EmitContext& ctx, Xby
     code.test(page_table, page_table);
     code.jz(abort, code.T_NEAR);
     code.mov(tmp, vaddr);
-    code.and_(tmp, static_cast<u32>(PAGE_SIZE - 1));
+    code.and_(tmp, static_cast<u32>(page_size - 1));
     return page_table + tmp;
 }
 


### PR DESCRIPTION
Android studio currently ships CMake 3.6 in it's SDK, which does not support `set(CMAKE_CXX_STANDARD 17)`
The NDK also reports the architecture as ARM64 instead of Aarch64 when compiling for 64 bit ARM targets.

The PAGE_SIZE macro in Android's user.h conflicts with a variable in `a64_emit_x64.cpp`. Considering it's not a header, the simplest solution was to undefine it.