### PR TITLE
constant_propagation_pass: Extend folding of sign-extension/zero-extension opcodes

### DIFF
--- a/src/ir_opt/constant_propagation_pass.cpp
+++ b/src/ir_opt/constant_propagation_pass.cpp
@@ -114,6 +114,15 @@ void FoldOR(IR::Inst& inst, bool is_32_bit) {
     }
 }
 
+void FoldSignExtendXToWord(IR::Inst& inst) {
+    if (!inst.AreAllArgsImmediates()) {
+        return;
+    }
+
+    const s64 value = inst.GetArg(0).GetImmediateAsS64();
+    inst.ReplaceUsesWith(IR::Value{static_cast<u32>(value)});
+}
+
 void FoldZeroExtendXToWord(IR::Inst& inst) {
     if (!inst.AreAllArgsImmediates()) {
         return;
@@ -171,6 +180,10 @@ void ConstantPropagation(IR::Block& block) {
         case IR::Opcode::Not32:
         case IR::Opcode::Not64:
             FoldNOT(inst, opcode == IR::Opcode::Not32);
+            break;
+        case IR::Opcode::SignExtendByteToWord:
+        case IR::Opcode::SignExtendHalfToWord:
+            FoldSignExtendXToWord(inst);
             break;
         case IR::Opcode::ZeroExtendByteToWord:
         case IR::Opcode::ZeroExtendHalfToWord:

--- a/src/ir_opt/constant_propagation_pass.cpp
+++ b/src/ir_opt/constant_propagation_pass.cpp
@@ -123,6 +123,15 @@ void FoldSignExtendXToWord(IR::Inst& inst) {
     inst.ReplaceUsesWith(IR::Value{static_cast<u32>(value)});
 }
 
+void FoldSignExtendXToLong(IR::Inst& inst) {
+    if (!inst.AreAllArgsImmediates()) {
+        return;
+    }
+
+    const s64 value = inst.GetArg(0).GetImmediateAsS64();
+    inst.ReplaceUsesWith(IR::Value{static_cast<u64>(value)});
+}
+
 void FoldZeroExtendXToWord(IR::Inst& inst) {
     if (!inst.AreAllArgsImmediates()) {
         return;
@@ -184,6 +193,11 @@ void ConstantPropagation(IR::Block& block) {
         case IR::Opcode::SignExtendByteToWord:
         case IR::Opcode::SignExtendHalfToWord:
             FoldSignExtendXToWord(inst);
+            break;
+        case IR::Opcode::SignExtendByteToLong:
+        case IR::Opcode::SignExtendHalfToLong:
+        case IR::Opcode::SignExtendWordToLong:
+            FoldSignExtendXToLong(inst);
             break;
         case IR::Opcode::ZeroExtendByteToWord:
         case IR::Opcode::ZeroExtendHalfToWord:

--- a/src/ir_opt/constant_propagation_pass.cpp
+++ b/src/ir_opt/constant_propagation_pass.cpp
@@ -122,6 +122,15 @@ void FoldZeroExtendXToWord(IR::Inst& inst) {
     const u64 value = inst.GetArg(0).GetImmediateAsU64();
     inst.ReplaceUsesWith(IR::Value{static_cast<u32>(value)});
 }
+
+void FoldZeroExtendXToLong(IR::Inst& inst) {
+    if (!inst.AreAllArgsImmediates()) {
+        return;
+    }
+
+    const u64 value = inst.GetArg(0).GetImmediateAsU64();
+    inst.ReplaceUsesWith(IR::Value{value});
+}
 } // Anonymous namespace
 
 void ConstantPropagation(IR::Block& block) {
@@ -166,6 +175,11 @@ void ConstantPropagation(IR::Block& block) {
         case IR::Opcode::ZeroExtendByteToWord:
         case IR::Opcode::ZeroExtendHalfToWord:
             FoldZeroExtendXToWord(inst);
+            break;
+        case IR::Opcode::ZeroExtendByteToLong:
+        case IR::Opcode::ZeroExtendHalfToLong:
+        case IR::Opcode::ZeroExtendWordToLong:
+            FoldZeroExtendXToLong(inst);
             break;
         default:
             break;


### PR DESCRIPTION
Adds folding for more of the extension opcodes. Now that we also have `GetImmediateAsS64()` function, we can also handle the sign-extension opcodes as well.