### PR TITLE
Remove always-true condition

### DIFF
--- a/src/frontend/A64/translate/impl/floating_point_conversion_integer.cpp
+++ b/src/frontend/A64/translate/impl/floating_point_conversion_integer.cpp
@@ -87,7 +87,7 @@ bool TranslatorVisitor::FMOV_float_gen(bool sf, Imm<2> type, Imm<1> rmode_0, Imm
     size_t part;
     switch (rmode_0.ZeroExtend()) {
     case 0b0:
-        if (fltsize != 16 && fltsize != intsize) {
+        if (fltsize != intsize) {
             return UnallocatedEncoding();
         }
         integer_to_float = opc_0 == 0b1;

--- a/src/frontend/A64/translate/impl/floating_point_conversion_integer.cpp
+++ b/src/frontend/A64/translate/impl/floating_point_conversion_integer.cpp
@@ -87,7 +87,8 @@ bool TranslatorVisitor::FMOV_float_gen(bool sf, Imm<2> type, Imm<1> rmode_0, Imm
     size_t part;
     switch (rmode_0.ZeroExtend()) {
     case 0b0:
-        if (fltsize != intsize) {
+        // fltsize != 16 is always true for now (late 2018), until half-float support is implemented.
+        if (fltsize != 16 && fltsize != intsize) {
             return UnallocatedEncoding();
         }
         integer_to_float = opc_0 == 0b1;


### PR DESCRIPTION
fltsize is only ever set to 16 on branch that immediately returns, there
is no point in checking it again, as the condition is always true.

https://github.com/MerryMage/dynarmic/blob/52e646408fffccc26a03383adeafb0afc435dde0/src/frontend/A64/translate/impl/floating_point_conversion_integer.cpp#L82-L83