### PR TITLE
fuzz_util: Simplify result return in InstructionGenerator's Generate() function

### DIFF
--- a/tests/fuzz_util.cpp
+++ b/tests/fuzz_util.cpp
@@ -56,8 +56,6 @@ InstructionGenerator::InstructionGenerator(const char* format){
 }
 
 u32 InstructionGenerator::Generate() const {
-    u32 inst;
-    u32 random = RandInt<u32>(0, 0xFFFFFFFF);
-    inst = bits | (random & ~mask);
-    return inst;
+    const u32 random = RandInt<u32>(0, 0xFFFFFFFF);
+    return bits | (random & ~mask);
 }


### PR DESCRIPTION
This can just be a simple direct return without a separated declaration and assignment.