### PR TITLE
frontend/{A32, A64}/ir_emitter: Mark PC() and AlignPC() as const-qualified member functions

### DIFF
--- a/src/frontend/A32/ir_emitter.cpp
+++ b/src/frontend/A32/ir_emitter.cpp
@@ -12,13 +12,13 @@ namespace Dynarmic::A32 {
 
 using Opcode = IR::Opcode;
 
-u32 IREmitter::PC() {
-    u32 offset = current_location.TFlag() ? 4 : 8;
+u32 IREmitter::PC() const {
+    const u32 offset = current_location.TFlag() ? 4 : 8;
     return current_location.PC() + offset;
 }
 
-u32 IREmitter::AlignPC(size_t alignment) {
-    u32 pc = PC();
+u32 IREmitter::AlignPC(size_t alignment) const {
+    const u32 pc = PC();
     return static_cast<u32>(pc - pc % alignment);
 }
 

--- a/src/frontend/A32/ir_emitter.h
+++ b/src/frontend/A32/ir_emitter.h
@@ -31,8 +31,8 @@ public:
 
     LocationDescriptor current_location;
 
-    u32 PC();
-    u32 AlignPC(size_t alignment);
+    u32 PC() const;
+    u32 AlignPC(size_t alignment) const;
 
     IR::U32 GetRegister(Reg source_reg);
     IR::U32U64 GetExtendedRegister(ExtReg source_reg);

--- a/src/frontend/A64/ir_emitter.cpp
+++ b/src/frontend/A64/ir_emitter.cpp
@@ -12,12 +12,12 @@ namespace Dynarmic::A64 {
 
 using Opcode = IR::Opcode;
 
-u64 IREmitter::PC() {
+u64 IREmitter::PC() const {
     return current_location->PC();
 }
 
-u64 IREmitter::AlignPC(size_t alignment) {
-    u64 pc = PC();
+u64 IREmitter::AlignPC(size_t alignment) const {
+    const u64 pc = PC();
     return static_cast<u64>(pc - pc % alignment);
 }
 

--- a/src/frontend/A64/ir_emitter.h
+++ b/src/frontend/A64/ir_emitter.h
@@ -31,8 +31,8 @@ public:
 
     std::optional<LocationDescriptor> current_location;
 
-    u64 PC();
-    u64 AlignPC(size_t alignment);
+    u64 PC() const;
+    u64 AlignPC(size_t alignment) const;
 
     void SetCheckBit(const IR::U1& value);
     IR::U1 GetCFlag();


### PR DESCRIPTION
In both IR emitters, these functions don't actually modify instance state, so they can be marked with a const qualifier.