### PR TITLE
tests/A32/fuzz_arm: Remove unused Unix-specific include

### DIFF
--- a/tests/A32/fuzz_arm.cpp
+++ b/tests/A32/fuzz_arm.cpp
@@ -34,10 +34,6 @@
 #include "A32/skyeye_interpreter/dyncom/arm_dyncom_interpreter.h"
 #include "A32/skyeye_interpreter/skyeye_common/armstate.h"
 
-#ifdef __unix__
-#include <signal.h>
-#endif
-
 using Dynarmic::Common::Bits;
 
 static Dynarmic::A32::UserConfig GetUserConfig(ArmTestEnv* testenv) {


### PR DESCRIPTION
This was introduced within 6f6f60c61b2137780102c75841441f760d3cc3fc, however, the relevant code that it was used with has since been removed, making the include unnecessary.