### PR TITLE
A32/translate_arm: Formatting/tidying up

### DIFF
--- a/src/frontend/A32/translate/translate_arm/branch.cpp
+++ b/src/frontend/A32/translate/translate_arm/branch.cpp
@@ -10,65 +10,75 @@
 
 namespace Dynarmic::A32 {
 
+// B <label>
 bool ArmTranslatorVisitor::arm_B(Cond cond, Imm24 imm24) {
-    u32 imm32 = Common::SignExtend<26, u32>(imm24 << 2) + 8;
-    // B <label>
-    if (ConditionPassed(cond)) {
-        auto new_location = ir.current_location.AdvancePC(imm32);
-        ir.SetTerm(IR::Term::LinkBlock{ new_location });
-        return false;
+    if (!ConditionPassed(cond)) {
+        return true;
     }
-    return true;
-}
 
-bool ArmTranslatorVisitor::arm_BL(Cond cond, Imm24 imm24) {
-    u32 imm32 = Common::SignExtend<26, u32>(imm24 << 2) + 8;
-    // BL <label>
-    if (ConditionPassed(cond)) {
-        ir.PushRSB(ir.current_location.AdvancePC(4));
-        ir.SetRegister(Reg::LR, ir.Imm32(ir.current_location.PC() + 4));
-        auto new_location = ir.current_location.AdvancePC(imm32);
-        ir.SetTerm(IR::Term::LinkBlock{ new_location });
-        return false;
-    }
-    return true;
-}
-
-bool ArmTranslatorVisitor::arm_BLX_imm(bool H, Imm24 imm24) {
-    u32 imm32 = Common::SignExtend<26, u32>((imm24 << 2)) + (H ? 2 : 0) + 8;
-    // BLX <label>
-    ir.PushRSB(ir.current_location.AdvancePC(4));
-    ir.SetRegister(Reg::LR, ir.Imm32(ir.current_location.PC() + 4));
-    auto new_location = ir.current_location.AdvancePC(imm32).SetTFlag(true);
-    ir.SetTerm(IR::Term::LinkBlock{ new_location });
+    const u32 imm32 = Common::SignExtend<26, u32>(imm24 << 2) + 8;
+    const auto new_location = ir.current_location.AdvancePC(imm32);
+    ir.SetTerm(IR::Term::LinkBlock{new_location});
     return false;
 }
 
-bool ArmTranslatorVisitor::arm_BLX_reg(Cond cond, Reg m) {
-    if (m == Reg::PC)
-        return UnpredictableInstruction();
-    // BLX <Rm>
-    if (ConditionPassed(cond)) {
-        ir.PushRSB(ir.current_location.AdvancePC(4));
-        ir.BXWritePC(ir.GetRegister(m));
-        ir.SetRegister(Reg::LR, ir.Imm32(ir.current_location.PC() + 4));
-        ir.SetTerm(IR::Term::FastDispatchHint{});
-        return false;
+// BL <label>
+bool ArmTranslatorVisitor::arm_BL(Cond cond, Imm24 imm24) {
+    if (!ConditionPassed(cond)) {
+        return true;
     }
-    return true;
+
+    ir.PushRSB(ir.current_location.AdvancePC(4));
+    ir.SetRegister(Reg::LR, ir.Imm32(ir.current_location.PC() + 4));
+
+    const u32 imm32 = Common::SignExtend<26, u32>(imm24 << 2) + 8;
+    const auto new_location = ir.current_location.AdvancePC(imm32);
+    ir.SetTerm(IR::Term::LinkBlock{new_location});
+    return false;
 }
 
-bool ArmTranslatorVisitor::arm_BX(Cond cond, Reg m) {
-    // BX <Rm>
-    if (ConditionPassed(cond)) {
-        ir.BXWritePC(ir.GetRegister(m));
-        if (m == Reg::R14)
-            ir.SetTerm(IR::Term::PopRSBHint{});
-        else
-            ir.SetTerm(IR::Term::FastDispatchHint{});
-        return false;
+// BLX <label>
+bool ArmTranslatorVisitor::arm_BLX_imm(bool H, Imm24 imm24) {
+    ir.PushRSB(ir.current_location.AdvancePC(4));
+    ir.SetRegister(Reg::LR, ir.Imm32(ir.current_location.PC() + 4));
+
+    const u32 imm32 = Common::SignExtend<26, u32>((imm24 << 2)) + (H ? 2 : 0) + 8;
+    const auto new_location = ir.current_location.AdvancePC(imm32).SetTFlag(true);
+    ir.SetTerm(IR::Term::LinkBlock{new_location});
+    return false;
+}
+
+// BLX <Rm>
+bool ArmTranslatorVisitor::arm_BLX_reg(Cond cond, Reg m) {
+    if (m == Reg::PC) {
+        return UnpredictableInstruction();
     }
-    return true;
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    ir.PushRSB(ir.current_location.AdvancePC(4));
+    ir.BXWritePC(ir.GetRegister(m));
+    ir.SetRegister(Reg::LR, ir.Imm32(ir.current_location.PC() + 4));
+    ir.SetTerm(IR::Term::FastDispatchHint{});
+    return false;
+}
+
+// BX <Rm>
+bool ArmTranslatorVisitor::arm_BX(Cond cond, Reg m) {
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    ir.BXWritePC(ir.GetRegister(m));
+    if (m == Reg::R14) {
+        ir.SetTerm(IR::Term::PopRSBHint{});
+    } else {
+        ir.SetTerm(IR::Term::FastDispatchHint{});
+    }
+
+    return false;
 }
 
 bool ArmTranslatorVisitor::arm_BXJ(Cond cond, Reg m) {

--- a/src/frontend/A32/translate/translate_arm/coprocessor.cpp
+++ b/src/frontend/A32/translate/translate_arm/coprocessor.cpp
@@ -8,36 +8,40 @@
 
 namespace Dynarmic::A32 {
 
+// CDP{2} <coproc_no>, #<opc1>, <CRd>, <CRn>, <CRm>, #<opc2>
 bool ArmTranslatorVisitor::arm_CDP(Cond cond, size_t opc1, CoprocReg CRn, CoprocReg CRd, size_t coproc_no, size_t opc2, CoprocReg CRm) {
-    if ((coproc_no & 0b1110) == 0b1010)
+    if ((coproc_no & 0b1110) == 0b1010) {
         return arm_UDF();
+    }
 
     const bool two = cond == Cond::NV;
 
-    // CDP{2} <coproc_no>, #<opc1>, <CRd>, <CRn>, <CRm>, #<opc2>
     if (two || ConditionPassed(cond)) {
         ir.CoprocInternalOperation(coproc_no, two, opc1, CRd, CRn, CRm, opc2);
     }
     return true;
 }
 
+// LDC{2}{L}<c> <coproc_no>, <CRd>, [<Rn>, #+/-<imm32>]{!}
+// LDC{2}{L}<c> <coproc_no>, <CRd>, [<Rn>], #+/-<imm32>
+// LDC{2}{L}<c> <coproc_no>, <CRd>, [<Rn>], <imm8>
 bool ArmTranslatorVisitor::arm_LDC(Cond cond, bool p, bool u, bool d, bool w, Reg n, CoprocReg CRd, size_t coproc_no, Imm8 imm8) {
-    if (!p && !u && !d && !w)
+    if (!p && !u && !d && !w) {
         return arm_UDF();
-    if ((coproc_no & 0b1110) == 0b1010)
+    }
+
+    if ((coproc_no & 0b1110) == 0b1010) {
         return arm_UDF();
+    }
 
     const bool two = cond == Cond::NV;
-    const u32 imm32 = static_cast<u8>(imm8) << 2;
-    const bool index = p;
-    const bool add = u;
-    const bool wback = w;
-    const bool has_option = !p && !w && u;
 
-    // LDC{2}{L} <coproc_no>, <CRd>, [<Rn>, #+/-<imm32>]{!}
-    // LDC{2}{L} <coproc_no>, <CRd>, [<Rn>], #+/-<imm32>
-    // LDC{2}{L} <coproc_no>, <CRd>, [<Rn>], <imm8>
     if (two || ConditionPassed(cond)) {
+        const u32 imm32 = static_cast<u8>(imm8) << 2;
+        const bool index = p;
+        const bool add = u;
+        const bool wback = w;
+        const bool has_option = !p && !w && u;
         const IR::U32 reg_n = ir.GetRegister(n);
         const IR::U32 offset_address = add ? ir.Add(reg_n, ir.Imm32(imm32)) : ir.Sub(reg_n, ir.Imm32(imm32));
         const IR::U32 address = index ? offset_address : reg_n;
@@ -49,91 +53,106 @@ bool ArmTranslatorVisitor::arm_LDC(Cond cond, bool p, bool u, bool d, bool w, Re
     return true;
 }
 
+// MCR{2}<c> <coproc_no>, #<opc1>, <Rt>, <CRn>, <CRm>, #<opc2>
 bool ArmTranslatorVisitor::arm_MCR(Cond cond, size_t opc1, CoprocReg CRn, Reg t, size_t coproc_no, size_t opc2, CoprocReg CRm) {
-    if ((coproc_no & 0b1110) == 0b1010)
+    if ((coproc_no & 0b1110) == 0b1010) {
         return arm_UDF();
-    if (t == Reg::PC)
+    }
+
+    if (t == Reg::PC) {
         return UnpredictableInstruction();
+    }
 
     const bool two = cond == Cond::NV;
 
-    // MCR{2} <coproc_no>, #<opc1>, <Rt>, <CRn>, <CRm>, #<opc2>
     if (two || ConditionPassed(cond)) {
         ir.CoprocSendOneWord(coproc_no, two, opc1, CRn, CRm, opc2, ir.GetRegister(t));
     }
     return true;
 }
 
+// MCRR{2}<c> <coproc_no>, #<opc>, <Rt>, <Rt2>, <CRm>
 bool ArmTranslatorVisitor::arm_MCRR(Cond cond, Reg t2, Reg t, size_t coproc_no, size_t opc, CoprocReg CRm) {
-    if ((coproc_no & 0b1110) == 0b1010)
+    if ((coproc_no & 0b1110) == 0b1010) {
         return arm_UDF();
-    if (t == Reg::PC || t2 == Reg::PC)
+    }
+
+    if (t == Reg::PC || t2 == Reg::PC) {
         return UnpredictableInstruction();
+    }
 
     const bool two = cond == Cond::NV;
 
-    // MCRR{2} <coproc_no>, #<opc>, <Rt>, <Rt2>, <CRm>
     if (two || ConditionPassed(cond)) {
         ir.CoprocSendTwoWords(coproc_no, two, opc, CRm, ir.GetRegister(t), ir.GetRegister(t2));
     }
     return true;
 }
 
+// MRC{2}<c> <coproc_no>, #<opc1>, <Rt>, <CRn>, <CRm>, #<opc2>
 bool ArmTranslatorVisitor::arm_MRC(Cond cond, size_t opc1, CoprocReg CRn, Reg t, size_t coproc_no, size_t opc2, CoprocReg CRm) {
-    if ((coproc_no & 0b1110) == 0b1010)
+    if ((coproc_no & 0b1110) == 0b1010) {
         return arm_UDF();
+    }
 
     const bool two = cond == Cond::NV;
 
-    // MRC{2} <coproc_no>, #<opc1>, <Rt>, <CRn>, <CRm>, #<opc2>
     if (two || ConditionPassed(cond)) {
-        auto word = ir.CoprocGetOneWord(coproc_no, two, opc1, CRn, CRm, opc2);
+        const auto word = ir.CoprocGetOneWord(coproc_no, two, opc1, CRn, CRm, opc2);
         if (t != Reg::PC) {
             ir.SetRegister(t, word);
         } else {
-            auto new_cpsr_nzcv = ir.And(word, ir.Imm32(0xF0000000));
+            const auto new_cpsr_nzcv = ir.And(word, ir.Imm32(0xF0000000));
             ir.SetCpsrNZCV(new_cpsr_nzcv);
         }
     }
     return true;
 }
 
+// MRRC{2}<c> <coproc_no>, #<opc>, <Rt>, <Rt2>, <CRm>
 bool ArmTranslatorVisitor::arm_MRRC(Cond cond, Reg t2, Reg t, size_t coproc_no, size_t opc, CoprocReg CRm) {
-    if ((coproc_no & 0b1110) == 0b1010)
+    if ((coproc_no & 0b1110) == 0b1010) {
         return arm_UDF();
-    if (t == Reg::PC || t2 == Reg::PC || t == t2)
+    }
+
+    if (t == Reg::PC || t2 == Reg::PC || t == t2) {
         return UnpredictableInstruction();
+    }
 
     const bool two = cond == Cond::NV;
 
-    // MRRC{2} <coproc_no>, #<opc>, <Rt>, <Rt2>, <CRm>
     if (two || ConditionPassed(cond)) {
-        auto two_words = ir.CoprocGetTwoWords(coproc_no, two, opc, CRm);
+        const auto two_words = ir.CoprocGetTwoWords(coproc_no, two, opc, CRm);
         ir.SetRegister(t, ir.LeastSignificantWord(two_words));
         ir.SetRegister(t2, ir.MostSignificantWord(two_words).result);
     }
     return true;
 }
 
+// STC{2}{L}<c> <coproc>, <CRd>, [<Rn>, #+/-<imm32>]{!}
+// STC{2}{L}<c> <coproc>, <CRd>, [<Rn>], #+/-<imm32>
+// STC{2}{L}<c> <coproc>, <CRd>, [<Rn>], <imm8>
 bool ArmTranslatorVisitor::arm_STC(Cond cond, bool p, bool u, bool d, bool w, Reg n, CoprocReg CRd, size_t coproc_no, Imm8 imm8) {
-    if ((coproc_no & 0b1110) == 0b1010)
+    if ((coproc_no & 0b1110) == 0b1010) {
         return arm_UDF();
-    if (!p && !u && !d && !w)
+    }
+
+    if (!p && !u && !d && !w) {
         return arm_UDF();
-    if (n == Reg::PC && w)
+    }
+
+    if (n == Reg::PC && w) {
         return UnpredictableInstruction();
+    }
 
     const bool two = cond == Cond::NV;
-    const u32 imm32 = static_cast<u8>(imm8) << 2;
-    const bool index = p;
-    const bool add = u;
-    const bool wback = w;
-    const bool has_option = !p && !w && u;
 
-    // STC{2}{L} <coproc>, <CRd>, [<Rn>, #+/-<imm32>]{!}
-    // STC{2}{L} <coproc>, <CRd>, [<Rn>], #+/-<imm32>
-    // STC{2}{L} <coproc>, <CRd>, [<Rn>], <imm8>
     if (two || ConditionPassed(cond)) {
+        const u32 imm32 = static_cast<u8>(imm8) << 2;
+        const bool index = p;
+        const bool add = u;
+        const bool wback = w;
+        const bool has_option = !p && !w && u;
         const IR::U32 reg_n = ir.GetRegister(n);
         const IR::U32 offset_address = add ? ir.Add(reg_n, ir.Imm32(imm32)) : ir.Sub(reg_n, ir.Imm32(imm32));
         const IR::U32 address = index ? offset_address : reg_n;

--- a/src/frontend/A32/translate/translate_arm/data_processing.cpp
+++ b/src/frontend/A32/translate/translate_arm/data_processing.cpp
@@ -8,883 +8,1229 @@
 
 namespace Dynarmic::A32 {
 
+// ADC{S}<c> <Rd>, <Rn>, #<imm>
 bool ArmTranslatorVisitor::arm_ADC_imm(Cond cond, bool S, Reg n, Reg d, int rotate, Imm8 imm8) {
-    // ADC{S}<c> <Rd>, <Rn>, #<imm>
-    if (ConditionPassed(cond)) {
-        u32 imm32 = ArmExpandImm(rotate, imm8);
-        auto result = ir.AddWithCarry(ir.GetRegister(n), ir.Imm32(imm32), ir.GetCFlag());
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
 
-        if (d == Reg::PC) {
-            if (S) return UnpredictableInstruction(); // This is UNPREDICTABLE when in user-mode.
-            ir.ALUWritePC(result.result);
-            ir.SetTerm(IR::Term::ReturnToDispatch{});
-            return false;
-        }
-
-        ir.SetRegister(d, result.result);
+    const u32 imm32 = ArmExpandImm(rotate, imm8);
+    const auto result = ir.AddWithCarry(ir.GetRegister(n), ir.Imm32(imm32), ir.GetCFlag());
+    if (d == Reg::PC) {
         if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result.result));
-            ir.SetZFlag(ir.IsZero(result.result));
-            ir.SetCFlag(result.carry);
-            ir.SetVFlag(result.overflow);
+            // This is UNPREDICTABLE when in user-mode.
+            return UnpredictableInstruction();
         }
+
+        ir.ALUWritePC(result.result);
+        ir.SetTerm(IR::Term::ReturnToDispatch{});
+        return false;
+    }
+
+    ir.SetRegister(d, result.result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result.result));
+        ir.SetZFlag(ir.IsZero(result.result));
+        ir.SetCFlag(result.carry);
+        ir.SetVFlag(result.overflow);
     }
     return true;
 }
 
+// ADC{S}<c> <Rd>, <Rn>, <Rm>{, <shift>}
 bool ArmTranslatorVisitor::arm_ADC_reg(Cond cond, bool S, Reg n, Reg d, Imm5 imm5, ShiftType shift, Reg m) {
-    if (ConditionPassed(cond)) {
-        auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, ir.GetCFlag());
-        auto result = ir.AddWithCarry(ir.GetRegister(n), shifted.result, ir.GetCFlag());
-        if (d == Reg::PC) {
-            if (S) return UnpredictableInstruction(); // This is UNPREDICTABLE when in user-mode.
-            ir.ALUWritePC(result.result);
-            ir.SetTerm(IR::Term::ReturnToDispatch{});
-            return false;
-        }
-        ir.SetRegister(d, result.result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result.result));
-            ir.SetZFlag(ir.IsZero(result.result));
-            ir.SetCFlag(result.carry);
-            ir.SetVFlag(result.overflow);
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, ir.GetCFlag());
+    const auto result = ir.AddWithCarry(ir.GetRegister(n), shifted.result, ir.GetCFlag());
+    if (d == Reg::PC) {
+        if (S) {
+            // This is UNPREDICTABLE when in user-mode.
+            return UnpredictableInstruction();
+        }
+
+        ir.ALUWritePC(result.result);
+        ir.SetTerm(IR::Term::ReturnToDispatch{});
+        return false;
+    }
+
+    ir.SetRegister(d, result.result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result.result));
+        ir.SetZFlag(ir.IsZero(result.result));
+        ir.SetCFlag(result.carry);
+        ir.SetVFlag(result.overflow);
+    }
+
     return true;
 }
 
+// ADC{S}<c> <Rd>, <Rn>, <Rm>, <type> <Rs>
 bool ArmTranslatorVisitor::arm_ADC_rsr(Cond cond, bool S, Reg n, Reg d, Reg s, ShiftType shift, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC || s == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC || s == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
-        auto carry_in = ir.GetCFlag();
-        auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
-        auto result = ir.AddWithCarry(ir.GetRegister(n), shifted.result, ir.GetCFlag());
-        ir.SetRegister(d, result.result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result.result));
-            ir.SetZFlag(ir.IsZero(result.result));
-            ir.SetCFlag(result.carry);
-            ir.SetVFlag(result.overflow);
-        }
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
+    const auto carry_in = ir.GetCFlag();
+    const auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
+    const auto result = ir.AddWithCarry(ir.GetRegister(n), shifted.result, ir.GetCFlag());
+
+    ir.SetRegister(d, result.result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result.result));
+        ir.SetZFlag(ir.IsZero(result.result));
+        ir.SetCFlag(result.carry);
+        ir.SetVFlag(result.overflow);
+    }
+
     return true;
 }
 
+// ADD{S}<c> <Rd>, <Rn>, #<const>
 bool ArmTranslatorVisitor::arm_ADD_imm(Cond cond, bool S, Reg n, Reg d, int rotate, Imm8 imm8) {
-    if (ConditionPassed(cond)) {
-        u32 imm32 = ArmExpandImm(rotate, imm8);
-        auto result = ir.AddWithCarry(ir.GetRegister(n), ir.Imm32(imm32), ir.Imm1(0));
-        if (d == Reg::PC) {
-            if (S) return UnpredictableInstruction(); // This is UNPREDICTABLE when in user-mode.
-            ir.ALUWritePC(result.result);
-            ir.SetTerm(IR::Term::ReturnToDispatch{});
-            return false;
-        }
-        ir.SetRegister(d, result.result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result.result));
-            ir.SetZFlag(ir.IsZero(result.result));
-            ir.SetCFlag(result.carry);
-            ir.SetVFlag(result.overflow);
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const u32 imm32 = ArmExpandImm(rotate, imm8);
+    const auto result = ir.AddWithCarry(ir.GetRegister(n), ir.Imm32(imm32), ir.Imm1(0));
+    if (d == Reg::PC) {
+        if (S) {
+            // This is UNPREDICTABLE when in user-mode.
+            return UnpredictableInstruction();
+        }
+
+        ir.ALUWritePC(result.result);
+        ir.SetTerm(IR::Term::ReturnToDispatch{});
+        return false;
+    }
+
+    ir.SetRegister(d, result.result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result.result));
+        ir.SetZFlag(ir.IsZero(result.result));
+        ir.SetCFlag(result.carry);
+        ir.SetVFlag(result.overflow);
+    }
+
     return true;
 }
 
+// ADD{S}<c> <Rd>, <Rn>, <Rm>{, <shift>}
 bool ArmTranslatorVisitor::arm_ADD_reg(Cond cond, bool S, Reg n, Reg d, Imm5 imm5, ShiftType shift, Reg m) {
-    if (ConditionPassed(cond)) {
-        auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, ir.GetCFlag());
-        auto result = ir.AddWithCarry(ir.GetRegister(n), shifted.result, ir.Imm1(0));
-        if (d == Reg::PC) {
-            if (S) return UnpredictableInstruction(); // This is UNPREDICTABLE when in user-mode.
-            ir.ALUWritePC(result.result);
-            ir.SetTerm(IR::Term::ReturnToDispatch{});
-            return false;
-        }
-        ir.SetRegister(d, result.result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result.result));
-            ir.SetZFlag(ir.IsZero(result.result));
-            ir.SetCFlag(result.carry);
-            ir.SetVFlag(result.overflow);
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, ir.GetCFlag());
+    const auto result = ir.AddWithCarry(ir.GetRegister(n), shifted.result, ir.Imm1(0));
+    if (d == Reg::PC) {
+        if (S) {
+            // This is UNPREDICTABLE when in user-mode.
+            return UnpredictableInstruction();
+        }
+
+        ir.ALUWritePC(result.result);
+        ir.SetTerm(IR::Term::ReturnToDispatch{});
+        return false;
+    }
+
+    ir.SetRegister(d, result.result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result.result));
+        ir.SetZFlag(ir.IsZero(result.result));
+        ir.SetCFlag(result.carry);
+        ir.SetVFlag(result.overflow);
+    }
+
     return true;
 }
 
+// ADD{S}<c> <Rd>, <Rn>, <Rm>, <type> <Rs>
 bool ArmTranslatorVisitor::arm_ADD_rsr(Cond cond, bool S, Reg n, Reg d, Reg s, ShiftType shift, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC || s == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC || s == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
-        auto carry_in = ir.GetCFlag();
-        auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
-        auto result = ir.AddWithCarry(ir.GetRegister(n), shifted.result, ir.Imm1(0));
-        ir.SetRegister(d, result.result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result.result));
-            ir.SetZFlag(ir.IsZero(result.result));
-            ir.SetCFlag(result.carry);
-            ir.SetVFlag(result.overflow);
-        }
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
+    const auto carry_in = ir.GetCFlag();
+    const auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
+    const auto result = ir.AddWithCarry(ir.GetRegister(n), shifted.result, ir.Imm1(0));
+
+    ir.SetRegister(d, result.result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result.result));
+        ir.SetZFlag(ir.IsZero(result.result));
+        ir.SetCFlag(result.carry);
+        ir.SetVFlag(result.overflow);
+    }
+
     return true;
 }
 
+// AND{S}<c> <Rd>, <Rn>, #<const>
 bool ArmTranslatorVisitor::arm_AND_imm(Cond cond, bool S, Reg n, Reg d, int rotate, Imm8 imm8) {
-    if (ConditionPassed(cond)) {
-        auto imm_carry = ArmExpandImm_C(rotate, imm8, ir.GetCFlag());
-        auto result = ir.And(ir.GetRegister(n), ir.Imm32(imm_carry.imm32));
-        if (d == Reg::PC) {
-            if (S) return UnpredictableInstruction(); // This is UNPREDICTABLE when in user-mode.
-            ir.ALUWritePC(result);
-            ir.SetTerm(IR::Term::ReturnToDispatch{});
-            return false;
-        }
-        ir.SetRegister(d, result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result));
-            ir.SetZFlag(ir.IsZero(result));
-            ir.SetCFlag(imm_carry.carry);
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto imm_carry = ArmExpandImm_C(rotate, imm8, ir.GetCFlag());
+    const auto result = ir.And(ir.GetRegister(n), ir.Imm32(imm_carry.imm32));
+    if (d == Reg::PC) {
+        if (S) {
+            // This is UNPREDICTABLE when in user-mode.
+            return UnpredictableInstruction();
+        }
+
+        ir.ALUWritePC(result);
+        ir.SetTerm(IR::Term::ReturnToDispatch{});
+        return false;
+    }
+
+    ir.SetRegister(d, result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result));
+        ir.SetZFlag(ir.IsZero(result));
+        ir.SetCFlag(imm_carry.carry);
+    }
+
     return true;
 }
 
+// AND{S}<c> <Rd>, <Rn>, <Rm>{, <shift>}
 bool ArmTranslatorVisitor::arm_AND_reg(Cond cond, bool S, Reg n, Reg d, Imm5 imm5, ShiftType shift, Reg m) {
-    if (ConditionPassed(cond)) {
-        auto carry_in = ir.GetCFlag();
-        auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, carry_in);
-        auto result = ir.And(ir.GetRegister(n), shifted.result);
-        if (d == Reg::PC) {
-            if (S) return UnpredictableInstruction(); // This is UNPREDICTABLE when in user-mode.
-            ir.ALUWritePC(result);
-            ir.SetTerm(IR::Term::ReturnToDispatch{});
-            return false;
-        }
-        ir.SetRegister(d, result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result));
-            ir.SetZFlag(ir.IsZero(result));
-            ir.SetCFlag(shifted.carry);
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto carry_in = ir.GetCFlag();
+    const auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, carry_in);
+    const auto result = ir.And(ir.GetRegister(n), shifted.result);
+    if (d == Reg::PC) {
+        if (S) {
+            // This is UNPREDICTABLE when in user-mode.
+            return UnpredictableInstruction();
+        }
+
+        ir.ALUWritePC(result);
+        ir.SetTerm(IR::Term::ReturnToDispatch{});
+        return false;
+    }
+    ir.SetRegister(d, result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result));
+        ir.SetZFlag(ir.IsZero(result));
+        ir.SetCFlag(shifted.carry);
+    }
+
     return true;
 }
 
+// AND{S}<c> <Rd>, <Rn>, <Rm>, <type> <Rs>
 bool ArmTranslatorVisitor::arm_AND_rsr(Cond cond, bool S, Reg n, Reg d, Reg s, ShiftType shift, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC || s == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC || s == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
-        auto carry_in = ir.GetCFlag();
-        auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
-        auto result = ir.And(ir.GetRegister(n), shifted.result);
-        ir.SetRegister(d, result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result));
-            ir.SetZFlag(ir.IsZero(result));
-            ir.SetCFlag(shifted.carry);
-        }
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
+    const auto carry_in = ir.GetCFlag();
+    const auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
+    const auto result = ir.And(ir.GetRegister(n), shifted.result);
+
+    ir.SetRegister(d, result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result));
+        ir.SetZFlag(ir.IsZero(result));
+        ir.SetCFlag(shifted.carry);
+    }
+
     return true;
 }
 
+// BIC{S}<c> <Rd>, <Rn>, #<const>
 bool ArmTranslatorVisitor::arm_BIC_imm(Cond cond, bool S, Reg n, Reg d, int rotate, Imm8 imm8) {
-    if (ConditionPassed(cond)) {
-        auto imm_carry = ArmExpandImm_C(rotate, imm8, ir.GetCFlag());
-        auto result = ir.And(ir.GetRegister(n), ir.Not(ir.Imm32(imm_carry.imm32)));
-        if (d == Reg::PC) {
-            if (S) return UnpredictableInstruction(); // This is UNPREDICTABLE when in user-mode.
-            ir.ALUWritePC(result);
-            ir.SetTerm(IR::Term::ReturnToDispatch{});
-            return false;
-        }
-        ir.SetRegister(d, result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result));
-            ir.SetZFlag(ir.IsZero(result));
-            ir.SetCFlag(imm_carry.carry);
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto imm_carry = ArmExpandImm_C(rotate, imm8, ir.GetCFlag());
+    const auto result = ir.And(ir.GetRegister(n), ir.Not(ir.Imm32(imm_carry.imm32)));
+    if (d == Reg::PC) {
+        if (S) {
+            // This is UNPREDICTABLE when in user-mode.
+            return UnpredictableInstruction();
+        }
+
+        ir.ALUWritePC(result);
+        ir.SetTerm(IR::Term::ReturnToDispatch{});
+        return false;
+    }
+
+    ir.SetRegister(d, result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result));
+        ir.SetZFlag(ir.IsZero(result));
+        ir.SetCFlag(imm_carry.carry);
+    }
+
     return true;
 }
 
+// BIC{S}<c> <Rd>, <Rn>, <Rm>{, <shift>}
 bool ArmTranslatorVisitor::arm_BIC_reg(Cond cond, bool S, Reg n, Reg d, Imm5 imm5, ShiftType shift, Reg m) {
-    if (ConditionPassed(cond)) {
-        auto carry_in = ir.GetCFlag();
-        auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, carry_in);
-        auto result = ir.And(ir.GetRegister(n), ir.Not(shifted.result));
-        if (d == Reg::PC) {
-            if (S) return UnpredictableInstruction(); // This is UNPREDICTABLE when in user-mode.
-            ir.ALUWritePC(result);
-            ir.SetTerm(IR::Term::ReturnToDispatch{});
-            return false;
-        }
-        ir.SetRegister(d, result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result));
-            ir.SetZFlag(ir.IsZero(result));
-            ir.SetCFlag(shifted.carry);
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto carry_in = ir.GetCFlag();
+    const auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, carry_in);
+    const auto result = ir.And(ir.GetRegister(n), ir.Not(shifted.result));
+    if (d == Reg::PC) {
+        if (S) {
+            // This is UNPREDICTABLE when in user-mode.
+            return UnpredictableInstruction();
+        }
+
+        ir.ALUWritePC(result);
+        ir.SetTerm(IR::Term::ReturnToDispatch{});
+        return false;
+    }
+
+    ir.SetRegister(d, result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result));
+        ir.SetZFlag(ir.IsZero(result));
+        ir.SetCFlag(shifted.carry);
+    }
+
     return true;
 }
 
+// BIC{S}<c> <Rd>, <Rn>, <Rm>, <type> <Rs>
 bool ArmTranslatorVisitor::arm_BIC_rsr(Cond cond, bool S, Reg n, Reg d, Reg s, ShiftType shift, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC || s == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC || s == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
-        auto carry_in = ir.GetCFlag();
-        auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
-        auto result = ir.And(ir.GetRegister(n), ir.Not(shifted.result));
-        ir.SetRegister(d, result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result));
-            ir.SetZFlag(ir.IsZero(result));
-            ir.SetCFlag(shifted.carry);
-        }
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
+    const auto carry_in = ir.GetCFlag();
+    const auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
+    const auto result = ir.And(ir.GetRegister(n), ir.Not(shifted.result));
+
+    ir.SetRegister(d, result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result));
+        ir.SetZFlag(ir.IsZero(result));
+        ir.SetCFlag(shifted.carry);
+    }
+
     return true;
 }
 
+// CMN<c> <Rn>, #<const>
 bool ArmTranslatorVisitor::arm_CMN_imm(Cond cond, Reg n, int rotate, Imm8 imm8) {
-    if (ConditionPassed(cond)) {
-        u32 imm32 = ArmExpandImm(rotate, imm8);
-        auto result = ir.AddWithCarry(ir.GetRegister(n), ir.Imm32(imm32), ir.Imm1(0));
-        ir.SetNFlag(ir.MostSignificantBit(result.result));
-        ir.SetZFlag(ir.IsZero(result.result));
-        ir.SetCFlag(result.carry);
-        ir.SetVFlag(result.overflow);
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const u32 imm32 = ArmExpandImm(rotate, imm8);
+    const auto result = ir.AddWithCarry(ir.GetRegister(n), ir.Imm32(imm32), ir.Imm1(0));
+
+    ir.SetNFlag(ir.MostSignificantBit(result.result));
+    ir.SetZFlag(ir.IsZero(result.result));
+    ir.SetCFlag(result.carry);
+    ir.SetVFlag(result.overflow);
     return true;
 }
 
+// CMN<c> <Rn>, <Rm>{, <shift>}
 bool ArmTranslatorVisitor::arm_CMN_reg(Cond cond, Reg n, Imm5 imm5, ShiftType shift, Reg m) {
-    if (ConditionPassed(cond)) {
-        auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, ir.GetCFlag());
-        auto result = ir.AddWithCarry(ir.GetRegister(n), shifted.result, ir.Imm1(0));
-        ir.SetNFlag(ir.MostSignificantBit(result.result));
-        ir.SetZFlag(ir.IsZero(result.result));
-        ir.SetCFlag(result.carry);
-        ir.SetVFlag(result.overflow);
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, ir.GetCFlag());
+    const auto result = ir.AddWithCarry(ir.GetRegister(n), shifted.result, ir.Imm1(0));
+
+    ir.SetNFlag(ir.MostSignificantBit(result.result));
+    ir.SetZFlag(ir.IsZero(result.result));
+    ir.SetCFlag(result.carry);
+    ir.SetVFlag(result.overflow);
     return true;
 }
 
+// CMN<c> <Rn>, <Rm>, <type> <Rs>
 bool ArmTranslatorVisitor::arm_CMN_rsr(Cond cond, Reg n, Reg s, ShiftType shift, Reg m) {
-    if (n == Reg::PC || m == Reg::PC || s == Reg::PC)
+    if (n == Reg::PC || m == Reg::PC || s == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
-        auto carry_in = ir.GetCFlag();
-        auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
-        auto result = ir.AddWithCarry(ir.GetRegister(n), shifted.result, ir.Imm1(0));
-        ir.SetNFlag(ir.MostSignificantBit(result.result));
-        ir.SetZFlag(ir.IsZero(result.result));
-        ir.SetCFlag(result.carry);
-        ir.SetVFlag(result.overflow);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
+    const auto carry_in = ir.GetCFlag();
+    const auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
+    const auto result = ir.AddWithCarry(ir.GetRegister(n), shifted.result, ir.Imm1(0));
+
+    ir.SetNFlag(ir.MostSignificantBit(result.result));
+    ir.SetZFlag(ir.IsZero(result.result));
+    ir.SetCFlag(result.carry);
+    ir.SetVFlag(result.overflow);
     return true;
 }
 
+// CMP<c> <Rn>, #<imm>
 bool ArmTranslatorVisitor::arm_CMP_imm(Cond cond, Reg n, int rotate, Imm8 imm8) {
-    // CMP<c> <Rn>, #<imm>
-    if (ConditionPassed(cond)) {
-        u32 imm32 = ArmExpandImm(rotate, imm8);
-        auto result = ir.SubWithCarry(ir.GetRegister(n), ir.Imm32(imm32), ir.Imm1(1));
-        ir.SetNFlag(ir.MostSignificantBit(result.result));
-        ir.SetZFlag(ir.IsZero(result.result));
-        ir.SetCFlag(result.carry);
-        ir.SetVFlag(result.overflow);
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const u32 imm32 = ArmExpandImm(rotate, imm8);
+    const auto result = ir.SubWithCarry(ir.GetRegister(n), ir.Imm32(imm32), ir.Imm1(1));
+
+    ir.SetNFlag(ir.MostSignificantBit(result.result));
+    ir.SetZFlag(ir.IsZero(result.result));
+    ir.SetCFlag(result.carry);
+    ir.SetVFlag(result.overflow);
     return true;
 }
 
+// CMP<c> <Rn>, <Rm>{, <shift>}
 bool ArmTranslatorVisitor::arm_CMP_reg(Cond cond, Reg n, Imm5 imm5, ShiftType shift, Reg m) {
-    if (ConditionPassed(cond)) {
-        auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, ir.GetCFlag());
-        auto result = ir.SubWithCarry(ir.GetRegister(n), shifted.result, ir.Imm1(1));
-        ir.SetNFlag(ir.MostSignificantBit(result.result));
-        ir.SetZFlag(ir.IsZero(result.result));
-        ir.SetCFlag(result.carry);
-        ir.SetVFlag(result.overflow);
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, ir.GetCFlag());
+    const auto result = ir.SubWithCarry(ir.GetRegister(n), shifted.result, ir.Imm1(1));
+
+    ir.SetNFlag(ir.MostSignificantBit(result.result));
+    ir.SetZFlag(ir.IsZero(result.result));
+    ir.SetCFlag(result.carry);
+    ir.SetVFlag(result.overflow);
     return true;
 }
 
+// CMP<c> <Rn>, <Rm>, <type> <Rs>
 bool ArmTranslatorVisitor::arm_CMP_rsr(Cond cond, Reg n, Reg s, ShiftType shift, Reg m) {
-    if (n == Reg::PC || m == Reg::PC || s == Reg::PC)
+    if (n == Reg::PC || m == Reg::PC || s == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
-        auto carry_in = ir.GetCFlag();
-        auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
-        auto result = ir.SubWithCarry(ir.GetRegister(n), shifted.result, ir.Imm1(1));
-        ir.SetNFlag(ir.MostSignificantBit(result.result));
-        ir.SetZFlag(ir.IsZero(result.result));
-        ir.SetCFlag(result.carry);
-        ir.SetVFlag(result.overflow);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
+    const auto carry_in = ir.GetCFlag();
+    const auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
+    const auto result = ir.SubWithCarry(ir.GetRegister(n), shifted.result, ir.Imm1(1));
+
+    ir.SetNFlag(ir.MostSignificantBit(result.result));
+    ir.SetZFlag(ir.IsZero(result.result));
+    ir.SetCFlag(result.carry);
+    ir.SetVFlag(result.overflow);
     return true;
 }
 
+// EOR{S}<c> <Rd>, <Rn>, #<const>
 bool ArmTranslatorVisitor::arm_EOR_imm(Cond cond, bool S, Reg n, Reg d, int rotate, Imm8 imm8) {
-    if (ConditionPassed(cond)) {
-        auto imm_carry = ArmExpandImm_C(rotate, imm8, ir.GetCFlag());
-        auto result = ir.Eor(ir.GetRegister(n), ir.Imm32(imm_carry.imm32));
-        if (d == Reg::PC) {
-            if (S) return UnpredictableInstruction(); // This is UNPREDICTABLE when in user-mode.
-            ir.ALUWritePC(result);
-            ir.SetTerm(IR::Term::ReturnToDispatch{});
-            return false;
-        }
-        ir.SetRegister(d, result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result));
-            ir.SetZFlag(ir.IsZero(result));
-            ir.SetCFlag(imm_carry.carry);
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto imm_carry = ArmExpandImm_C(rotate, imm8, ir.GetCFlag());
+    const auto result = ir.Eor(ir.GetRegister(n), ir.Imm32(imm_carry.imm32));
+    if (d == Reg::PC) {
+        if (S) {
+            // This is UNPREDICTABLE when in user-mode.
+            return UnpredictableInstruction();
+        }
+
+        ir.ALUWritePC(result);
+        ir.SetTerm(IR::Term::ReturnToDispatch{});
+        return false;
+    }
+
+    ir.SetRegister(d, result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result));
+        ir.SetZFlag(ir.IsZero(result));
+        ir.SetCFlag(imm_carry.carry);
+    }
+
     return true;
 }
 
+// EOR{S}<c> <Rd>, <Rn>, <Rm>{, <shift>}
 bool ArmTranslatorVisitor::arm_EOR_reg(Cond cond, bool S, Reg n, Reg d, Imm5 imm5, ShiftType shift, Reg m) {
-    if (ConditionPassed(cond)) {
-        auto carry_in = ir.GetCFlag();
-        auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, carry_in);
-        auto result = ir.Eor(ir.GetRegister(n), shifted.result);
-        if (d == Reg::PC) {
-            if (S) return UnpredictableInstruction(); // This is UNPREDICTABLE when in user-mode.
-            ir.ALUWritePC(result);
-            ir.SetTerm(IR::Term::ReturnToDispatch{});
-            return false;
-        }
-        ir.SetRegister(d, result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result));
-            ir.SetZFlag(ir.IsZero(result));
-            ir.SetCFlag(shifted.carry);
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto carry_in = ir.GetCFlag();
+    const auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, carry_in);
+    const auto result = ir.Eor(ir.GetRegister(n), shifted.result);
+    if (d == Reg::PC) {
+        if (S) {
+            // This is UNPREDICTABLE when in user-mode.
+            return UnpredictableInstruction();
+        }
+
+        ir.ALUWritePC(result);
+        ir.SetTerm(IR::Term::ReturnToDispatch{});
+        return false;
+    }
+
+    ir.SetRegister(d, result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result));
+        ir.SetZFlag(ir.IsZero(result));
+        ir.SetCFlag(shifted.carry);
+    }
+
     return true;
 }
 
+// EOR{S}<c> <Rd>, <Rn>, <Rm>, <type> <Rs>
 bool ArmTranslatorVisitor::arm_EOR_rsr(Cond cond, bool S, Reg n, Reg d, Reg s, ShiftType shift, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC || s == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC || s == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
-        auto carry_in = ir.GetCFlag();
-        auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
-        auto result = ir.Eor(ir.GetRegister(n), shifted.result);
-        ir.SetRegister(d, result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result));
-            ir.SetZFlag(ir.IsZero(result));
-            ir.SetCFlag(shifted.carry);
-        }
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
+    const auto carry_in = ir.GetCFlag();
+    const auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
+    const auto result = ir.Eor(ir.GetRegister(n), shifted.result);
+
+    ir.SetRegister(d, result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result));
+        ir.SetZFlag(ir.IsZero(result));
+        ir.SetCFlag(shifted.carry);
+    }
+
     return true;
 }
 
+// MOV{S}<c> <Rd>, #<const>
 bool ArmTranslatorVisitor::arm_MOV_imm(Cond cond, bool S, Reg d, int rotate, Imm8 imm8) {
-    if (ConditionPassed(cond)) {
-        auto imm_carry = ArmExpandImm_C(rotate, imm8, ir.GetCFlag());
-        auto result = ir.Imm32(imm_carry.imm32);
-        if (d == Reg::PC) {
-            if (S) return UnpredictableInstruction(); // This is UNPREDICTABLE when in user-mode.
-            ir.ALUWritePC(result);
-            ir.SetTerm(IR::Term::ReturnToDispatch{});
-            return false;
-        }
-        ir.SetRegister(d, result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result));
-            ir.SetZFlag(ir.IsZero(result));
-            ir.SetCFlag(imm_carry.carry);
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto imm_carry = ArmExpandImm_C(rotate, imm8, ir.GetCFlag());
+    const auto result = ir.Imm32(imm_carry.imm32);
+    if (d == Reg::PC) {
+        if (S) {
+            // This is UNPREDICTABLE when in user-mode.
+            return UnpredictableInstruction();
+        }
+
+        ir.ALUWritePC(result);
+        ir.SetTerm(IR::Term::ReturnToDispatch{});
+        return false;
+    }
+
+    ir.SetRegister(d, result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result));
+        ir.SetZFlag(ir.IsZero(result));
+        ir.SetCFlag(imm_carry.carry);
+    }
+
     return true;
 }
 
+// MOV{S}<c> <Rd>, <Rm>
 bool ArmTranslatorVisitor::arm_MOV_reg(Cond cond, bool S, Reg d, Imm5 imm5, ShiftType shift, Reg m) {
-    if (ConditionPassed(cond)) {
-        auto carry_in = ir.GetCFlag();
-        auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, carry_in);
-        auto result = shifted.result;
-        if (d == Reg::PC) {
-            if (S) return UnpredictableInstruction(); // This is UNPREDICTABLE when in user-mode.
-            ir.ALUWritePC(result);
-            ir.SetTerm(IR::Term::ReturnToDispatch{});
-            return false;
-        }
-        ir.SetRegister(d, result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result));
-            ir.SetZFlag(ir.IsZero(result));
-            ir.SetCFlag(shifted.carry);
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto carry_in = ir.GetCFlag();
+    const auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, carry_in);
+    const auto result = shifted.result;
+    if (d == Reg::PC) {
+        if (S) {
+            // This is UNPREDICTABLE when in user-mode.
+            return UnpredictableInstruction();
+        }
+
+        ir.ALUWritePC(result);
+        ir.SetTerm(IR::Term::ReturnToDispatch{});
+        return false;
+    }
+
+    ir.SetRegister(d, result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result));
+        ir.SetZFlag(ir.IsZero(result));
+        ir.SetCFlag(shifted.carry);
+    }
+
     return true;
 }
 
 bool ArmTranslatorVisitor::arm_MOV_rsr(Cond cond, bool S, Reg d, Reg s, ShiftType shift, Reg m) {
-    if (d == Reg::PC || m == Reg::PC || s == Reg::PC)
+    if (d == Reg::PC || m == Reg::PC || s == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
-        auto carry_in = ir.GetCFlag();
-        auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
-        auto result = shifted.result;
-        ir.SetRegister(d, result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result));
-            ir.SetZFlag(ir.IsZero(result));
-            ir.SetCFlag(shifted.carry);
-        }
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
+    const auto carry_in = ir.GetCFlag();
+    const auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
+    const auto result = shifted.result;
+    ir.SetRegister(d, result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result));
+        ir.SetZFlag(ir.IsZero(result));
+        ir.SetCFlag(shifted.carry);
+    }
+
     return true;
 }
 
+// MVN{S}<c> <Rd>, #<const>
 bool ArmTranslatorVisitor::arm_MVN_imm(Cond cond, bool S, Reg d, int rotate, Imm8 imm8) {
-    if (ConditionPassed(cond)) {
-        auto imm_carry = ArmExpandImm_C(rotate, imm8, ir.GetCFlag());
-        auto result = ir.Not(ir.Imm32(imm_carry.imm32));
-        if (d == Reg::PC) {
-            if (S) return UnpredictableInstruction(); // This is UNPREDICTABLE when in user-mode.
-            ir.ALUWritePC(result);
-            ir.SetTerm(IR::Term::ReturnToDispatch{});
-            return false;
-        }
-        ir.SetRegister(d, result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result));
-            ir.SetZFlag(ir.IsZero(result));
-            ir.SetCFlag(imm_carry.carry);
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto imm_carry = ArmExpandImm_C(rotate, imm8, ir.GetCFlag());
+    const auto result = ir.Not(ir.Imm32(imm_carry.imm32));
+    if (d == Reg::PC) {
+        if (S) {
+            // This is UNPREDICTABLE when in user-mode.
+            return UnpredictableInstruction();
+        }
+
+        ir.ALUWritePC(result);
+        ir.SetTerm(IR::Term::ReturnToDispatch{});
+        return false;
+    }
+
+    ir.SetRegister(d, result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result));
+        ir.SetZFlag(ir.IsZero(result));
+        ir.SetCFlag(imm_carry.carry);
+    }
+
     return true;
 }
 
+// MVN{S}<c> <Rd>, <Rm>{, <shift>}
 bool ArmTranslatorVisitor::arm_MVN_reg(Cond cond, bool S, Reg d, Imm5 imm5, ShiftType shift, Reg m) {
-    if (ConditionPassed(cond)) {
-        auto carry_in = ir.GetCFlag();
-        auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, carry_in);
-        auto result = ir.Not(shifted.result);
-        if (d == Reg::PC) {
-            if (S) return UnpredictableInstruction(); // This is UNPREDICTABLE when in user-mode.
-            ir.ALUWritePC(result);
-            ir.SetTerm(IR::Term::ReturnToDispatch{});
-            return false;
-        }
-        ir.SetRegister(d, result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result));
-            ir.SetZFlag(ir.IsZero(result));
-            ir.SetCFlag(shifted.carry);
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto carry_in = ir.GetCFlag();
+    const auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, carry_in);
+    const auto result = ir.Not(shifted.result);
+    if (d == Reg::PC) {
+        if (S) {
+            // This is UNPREDICTABLE when in user-mode.
+            return UnpredictableInstruction();
+        }
+
+        ir.ALUWritePC(result);
+        ir.SetTerm(IR::Term::ReturnToDispatch{});
+        return false;
+    }
+
+    ir.SetRegister(d, result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result));
+        ir.SetZFlag(ir.IsZero(result));
+        ir.SetCFlag(shifted.carry);
+    }
+
     return true;
 }
 
+// MVN{S}<c> <Rd>, <Rm>, <type> <Rs>
 bool ArmTranslatorVisitor::arm_MVN_rsr(Cond cond, bool S, Reg d, Reg s, ShiftType shift, Reg m) {
-    if (d == Reg::PC || m == Reg::PC || s == Reg::PC)
+    if (d == Reg::PC || m == Reg::PC || s == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
-        auto carry_in = ir.GetCFlag();
-        auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
-        auto result = ir.Not(shifted.result);
-        ir.SetRegister(d, result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result));
-            ir.SetZFlag(ir.IsZero(result));
-            ir.SetCFlag(shifted.carry);
-        }
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
+    const auto carry_in = ir.GetCFlag();
+    const auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
+    const auto result = ir.Not(shifted.result);
+
+    ir.SetRegister(d, result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result));
+        ir.SetZFlag(ir.IsZero(result));
+        ir.SetCFlag(shifted.carry);
+    }
+
     return true;
 }
 
+// ORR{S}<c> <Rd>, <Rn>, #<const>
 bool ArmTranslatorVisitor::arm_ORR_imm(Cond cond, bool S, Reg n, Reg d, int rotate, Imm8 imm8) {
-    if (ConditionPassed(cond)) {
-        auto imm_carry = ArmExpandImm_C(rotate, imm8, ir.GetCFlag());
-        auto result = ir.Or(ir.GetRegister(n), ir.Imm32(imm_carry.imm32));
-        if (d == Reg::PC) {
-            if (S) return UnpredictableInstruction(); // This is UNPREDICTABLE when in user-mode.
-            ir.ALUWritePC(result);
-            ir.SetTerm(IR::Term::ReturnToDispatch{});
-            return false;
-        }
-        ir.SetRegister(d, result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result));
-            ir.SetZFlag(ir.IsZero(result));
-            ir.SetCFlag(imm_carry.carry);
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto imm_carry = ArmExpandImm_C(rotate, imm8, ir.GetCFlag());
+    const auto result = ir.Or(ir.GetRegister(n), ir.Imm32(imm_carry.imm32));
+    if (d == Reg::PC) {
+        if (S) {
+            // This is UNPREDICTABLE when in user-mode.
+            return UnpredictableInstruction();
+        }
+
+        ir.ALUWritePC(result);
+        ir.SetTerm(IR::Term::ReturnToDispatch{});
+        return false;
+    }
+
+    ir.SetRegister(d, result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result));
+        ir.SetZFlag(ir.IsZero(result));
+        ir.SetCFlag(imm_carry.carry);
+    }
+
     return true;
 }
 
+// ORR{S}<c> <Rd>, <Rn>, <Rm>{, <shift>}
 bool ArmTranslatorVisitor::arm_ORR_reg(Cond cond, bool S, Reg n, Reg d, Imm5 imm5, ShiftType shift, Reg m) {
-    if (ConditionPassed(cond)) {
-        auto carry_in = ir.GetCFlag();
-        auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, carry_in);
-        auto result = ir.Or(ir.GetRegister(n), shifted.result);
-        if (d == Reg::PC) {
-            if (S) return UnpredictableInstruction(); // This is UNPREDICTABLE when in user-mode.
-            ir.ALUWritePC(result);
-            ir.SetTerm(IR::Term::ReturnToDispatch{});
-            return false;
-        }
-        ir.SetRegister(d, result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result));
-            ir.SetZFlag(ir.IsZero(result));
-            ir.SetCFlag(shifted.carry);
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto carry_in = ir.GetCFlag();
+    const auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, carry_in);
+    const auto result = ir.Or(ir.GetRegister(n), shifted.result);
+    if (d == Reg::PC) {
+        if (S) {
+            // This is UNPREDICTABLE when in user-mode.
+            return UnpredictableInstruction();
+        }
+
+        ir.ALUWritePC(result);
+        ir.SetTerm(IR::Term::ReturnToDispatch{});
+        return false;
+    }
+
+    ir.SetRegister(d, result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result));
+        ir.SetZFlag(ir.IsZero(result));
+        ir.SetCFlag(shifted.carry);
+    }
+
     return true;
 }
 
+// ORR{S}<c> <Rd>, <Rn>, <Rm>, <type> <Rs>
 bool ArmTranslatorVisitor::arm_ORR_rsr(Cond cond, bool S, Reg n, Reg d, Reg s, ShiftType shift, Reg m) {
-    if (n == Reg::PC || m == Reg::PC || s == Reg::PC || d == Reg::PC)
+    if (n == Reg::PC || m == Reg::PC || s == Reg::PC || d == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
-        auto carry_in = ir.GetCFlag();
-        auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
-        auto result = ir.Or(ir.GetRegister(n), shifted.result);
-        ir.SetRegister(d, result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result));
-            ir.SetZFlag(ir.IsZero(result));
-            ir.SetCFlag(shifted.carry);
-        }
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
+    const auto carry_in = ir.GetCFlag();
+    const auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
+    const auto result = ir.Or(ir.GetRegister(n), shifted.result);
+
+    ir.SetRegister(d, result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result));
+        ir.SetZFlag(ir.IsZero(result));
+        ir.SetCFlag(shifted.carry);
+    }
+
     return true;
 }
 
+// RSB{S}<c> <Rd>, <Rn>, #<const>
 bool ArmTranslatorVisitor::arm_RSB_imm(Cond cond, bool S, Reg n, Reg d, int rotate, Imm8 imm8) {
-    if (ConditionPassed(cond)) {
-        u32 imm32 = ArmExpandImm(rotate, imm8);
-        auto result = ir.SubWithCarry(ir.Imm32(imm32), ir.GetRegister(n), ir.Imm1(1));
-        if (d == Reg::PC) {
-            if (S) return UnpredictableInstruction(); // This is UNPREDICTABLE when in user-mode.
-            ir.ALUWritePC(result.result);
-            ir.SetTerm(IR::Term::ReturnToDispatch{});
-            return false;
-        }
-        ir.SetRegister(d, result.result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result.result));
-            ir.SetZFlag(ir.IsZero(result.result));
-            ir.SetCFlag(result.carry);
-            ir.SetVFlag(result.overflow);
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const u32 imm32 = ArmExpandImm(rotate, imm8);
+    const auto result = ir.SubWithCarry(ir.Imm32(imm32), ir.GetRegister(n), ir.Imm1(1));
+    if (d == Reg::PC) {
+        if (S) {
+            // This is UNPREDICTABLE when in user-mode.
+            return UnpredictableInstruction();
+        }
+
+        ir.ALUWritePC(result.result);
+        ir.SetTerm(IR::Term::ReturnToDispatch{});
+        return false;
+    }
+
+    ir.SetRegister(d, result.result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result.result));
+        ir.SetZFlag(ir.IsZero(result.result));
+        ir.SetCFlag(result.carry);
+        ir.SetVFlag(result.overflow);
+    }
+
     return true;
 }
 
+// RSB{S}<c> <Rd>, <Rn>, <Rm>{, <shift>}
 bool ArmTranslatorVisitor::arm_RSB_reg(Cond cond, bool S, Reg n, Reg d, Imm5 imm5, ShiftType shift, Reg m) {
-    if (ConditionPassed(cond)) {
-        auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, ir.GetCFlag());
-        auto result = ir.SubWithCarry(shifted.result, ir.GetRegister(n), ir.Imm1(1));
-        if (d == Reg::PC) {
-            if (S) return UnpredictableInstruction(); // This is UNPREDICTABLE when in user-mode.
-            ir.ALUWritePC(result.result);
-            ir.SetTerm(IR::Term::ReturnToDispatch{});
-            return false;
-        }
-        ir.SetRegister(d, result.result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result.result));
-            ir.SetZFlag(ir.IsZero(result.result));
-            ir.SetCFlag(result.carry);
-            ir.SetVFlag(result.overflow);
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, ir.GetCFlag());
+    const auto result = ir.SubWithCarry(shifted.result, ir.GetRegister(n), ir.Imm1(1));
+    if (d == Reg::PC) {
+        if (S) {
+            // This is UNPREDICTABLE when in user-mode.
+            return UnpredictableInstruction();
+        }
+
+        ir.ALUWritePC(result.result);
+        ir.SetTerm(IR::Term::ReturnToDispatch{});
+        return false;
+    }
+
+    ir.SetRegister(d, result.result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result.result));
+        ir.SetZFlag(ir.IsZero(result.result));
+        ir.SetCFlag(result.carry);
+        ir.SetVFlag(result.overflow);
+    }
+
     return true;
 }
 
+// RSB{S}<c> <Rd>, <Rn>, <Rm>, <type> <Rs>
 bool ArmTranslatorVisitor::arm_RSB_rsr(Cond cond, bool S, Reg n, Reg d, Reg s, ShiftType shift, Reg m) {
-    if (n == Reg::PC || m == Reg::PC || s == Reg::PC || d == Reg::PC)
+    if (n == Reg::PC || m == Reg::PC || s == Reg::PC || d == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
-        auto carry_in = ir.GetCFlag();
-        auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
-        auto result = ir.SubWithCarry(shifted.result, ir.GetRegister(n), ir.Imm1(1));
-        ir.SetRegister(d, result.result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result.result));
-            ir.SetZFlag(ir.IsZero(result.result));
-            ir.SetCFlag(result.carry);
-            ir.SetVFlag(result.overflow);
-        }
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
+    const auto carry_in = ir.GetCFlag();
+    const auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
+    const auto result = ir.SubWithCarry(shifted.result, ir.GetRegister(n), ir.Imm1(1));
+
+    ir.SetRegister(d, result.result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result.result));
+        ir.SetZFlag(ir.IsZero(result.result));
+        ir.SetCFlag(result.carry);
+        ir.SetVFlag(result.overflow);
+    }
+
     return true;
 }
 
+// RSC{S}<c> <Rd>, <Rn>, #<const>
 bool ArmTranslatorVisitor::arm_RSC_imm(Cond cond, bool S, Reg n, Reg d, int rotate, Imm8 imm8) {
-    if (ConditionPassed(cond)) {
-        u32 imm32 = ArmExpandImm(rotate, imm8);
-        auto result = ir.SubWithCarry(ir.Imm32(imm32), ir.GetRegister(n), ir.GetCFlag());
-        if (d == Reg::PC) {
-            if (S) return UnpredictableInstruction(); // This is UNPREDICTABLE when in user-mode.
-            ir.ALUWritePC(result.result);
-            ir.SetTerm(IR::Term::ReturnToDispatch{});
-            return false;
-        }
-        ir.SetRegister(d, result.result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result.result));
-            ir.SetZFlag(ir.IsZero(result.result));
-            ir.SetCFlag(result.carry);
-            ir.SetVFlag(result.overflow);
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const u32 imm32 = ArmExpandImm(rotate, imm8);
+    const auto result = ir.SubWithCarry(ir.Imm32(imm32), ir.GetRegister(n), ir.GetCFlag());
+    if (d == Reg::PC) {
+        if (S) {
+            // This is UNPREDICTABLE when in user-mode.
+            return UnpredictableInstruction();
+        }
+
+        ir.ALUWritePC(result.result);
+        ir.SetTerm(IR::Term::ReturnToDispatch{});
+        return false;
+    }
+
+    ir.SetRegister(d, result.result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result.result));
+        ir.SetZFlag(ir.IsZero(result.result));
+        ir.SetCFlag(result.carry);
+        ir.SetVFlag(result.overflow);
+    }
+
     return true;
 }
 
 bool ArmTranslatorVisitor::arm_RSC_reg(Cond cond, bool S, Reg n, Reg d, Imm5 imm5, ShiftType shift, Reg m) {
-    if (ConditionPassed(cond)) {
-        auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, ir.GetCFlag());
-        auto result = ir.SubWithCarry(shifted.result, ir.GetRegister(n), ir.GetCFlag());
-        if (d == Reg::PC) {
-            if (S) return UnpredictableInstruction(); // This is UNPREDICTABLE when in user-mode.
-            ir.ALUWritePC(result.result);
-            ir.SetTerm(IR::Term::ReturnToDispatch{});
-            return false;
-        }
-        ir.SetRegister(d, result.result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result.result));
-            ir.SetZFlag(ir.IsZero(result.result));
-            ir.SetCFlag(result.carry);
-            ir.SetVFlag(result.overflow);
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, ir.GetCFlag());
+    const auto result = ir.SubWithCarry(shifted.result, ir.GetRegister(n), ir.GetCFlag());
+    if (d == Reg::PC) {
+        if (S) {
+            // This is UNPREDICTABLE when in user-mode.
+            return UnpredictableInstruction();
+        }
+
+        ir.ALUWritePC(result.result);
+        ir.SetTerm(IR::Term::ReturnToDispatch{});
+        return false;
+    }
+
+    ir.SetRegister(d, result.result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result.result));
+        ir.SetZFlag(ir.IsZero(result.result));
+        ir.SetCFlag(result.carry);
+        ir.SetVFlag(result.overflow);
+    }
+
     return true;
 }
 
+// RSC{S}<c> <Rd>, <Rn>, <Rm>{, <shift>}
 bool ArmTranslatorVisitor::arm_RSC_rsr(Cond cond, bool S, Reg n, Reg d, Reg s, ShiftType shift, Reg m) {
-    if (n == Reg::PC || m == Reg::PC || s == Reg::PC || d == Reg::PC)
+    if (n == Reg::PC || m == Reg::PC || s == Reg::PC || d == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
-        auto carry_in = ir.GetCFlag();
-        auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
-        auto result = ir.SubWithCarry(shifted.result, ir.GetRegister(n), ir.GetCFlag());
-        ir.SetRegister(d, result.result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result.result));
-            ir.SetZFlag(ir.IsZero(result.result));
-            ir.SetCFlag(result.carry);
-            ir.SetVFlag(result.overflow);
-        }
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
+    const auto carry_in = ir.GetCFlag();
+    const auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
+    const auto result = ir.SubWithCarry(shifted.result, ir.GetRegister(n), ir.GetCFlag());
+
+    ir.SetRegister(d, result.result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result.result));
+        ir.SetZFlag(ir.IsZero(result.result));
+        ir.SetCFlag(result.carry);
+        ir.SetVFlag(result.overflow);
+    }
+
     return true;
 }
 
+// SBC{S}<c> <Rd>, <Rn>, #<const>
 bool ArmTranslatorVisitor::arm_SBC_imm(Cond cond, bool S, Reg n, Reg d, int rotate, Imm8 imm8) {
-    if (ConditionPassed(cond)) {
-        u32 imm32 = ArmExpandImm(rotate, imm8);
-        auto result = ir.SubWithCarry(ir.GetRegister(n), ir.Imm32(imm32), ir.GetCFlag());
-        if (d == Reg::PC) {
-            if (S) return UnpredictableInstruction(); // This is UNPREDICTABLE when in user-mode.
-            ir.ALUWritePC(result.result);
-            ir.SetTerm(IR::Term::ReturnToDispatch{});
-            return false;
-        }
-        ir.SetRegister(d, result.result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result.result));
-            ir.SetZFlag(ir.IsZero(result.result));
-            ir.SetCFlag(result.carry);
-            ir.SetVFlag(result.overflow);
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const u32 imm32 = ArmExpandImm(rotate, imm8);
+    const auto result = ir.SubWithCarry(ir.GetRegister(n), ir.Imm32(imm32), ir.GetCFlag());
+    if (d == Reg::PC) {
+        if (S) {
+            // This is UNPREDICTABLE when in user-mode.
+            return UnpredictableInstruction();
+        }
+
+        ir.ALUWritePC(result.result);
+        ir.SetTerm(IR::Term::ReturnToDispatch{});
+        return false;
+    }
+
+    ir.SetRegister(d, result.result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result.result));
+        ir.SetZFlag(ir.IsZero(result.result));
+        ir.SetCFlag(result.carry);
+        ir.SetVFlag(result.overflow);
+    }
+
     return true;
 }
 
+// SBC{S}<c> <Rd>, <Rn>, <Rm>{, <shift>}
 bool ArmTranslatorVisitor::arm_SBC_reg(Cond cond, bool S, Reg n, Reg d, Imm5 imm5, ShiftType shift, Reg m) {
-    if (ConditionPassed(cond)) {
-        auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, ir.GetCFlag());
-        auto result = ir.SubWithCarry(ir.GetRegister(n), shifted.result, ir.GetCFlag());
-        if (d == Reg::PC) {
-            if (S) return UnpredictableInstruction(); // This is UNPREDICTABLE when in user-mode.
-            ir.ALUWritePC(result.result);
-            ir.SetTerm(IR::Term::ReturnToDispatch{});
-            return false;
-        }
-        ir.SetRegister(d, result.result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result.result));
-            ir.SetZFlag(ir.IsZero(result.result));
-            ir.SetCFlag(result.carry);
-            ir.SetVFlag(result.overflow);
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, ir.GetCFlag());
+    const auto result = ir.SubWithCarry(ir.GetRegister(n), shifted.result, ir.GetCFlag());
+    if (d == Reg::PC) {
+        if (S) {
+            // This is UNPREDICTABLE when in user-mode.
+            return UnpredictableInstruction();
+        }
+
+        ir.ALUWritePC(result.result);
+        ir.SetTerm(IR::Term::ReturnToDispatch{});
+        return false;
+    }
+
+    ir.SetRegister(d, result.result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result.result));
+        ir.SetZFlag(ir.IsZero(result.result));
+        ir.SetCFlag(result.carry);
+        ir.SetVFlag(result.overflow);
+    }
+
     return true;
 }
 
+// SBC{S}<c> <Rd>, <Rn>, <Rm>, <type> <Rs>
 bool ArmTranslatorVisitor::arm_SBC_rsr(Cond cond, bool S, Reg n, Reg d, Reg s, ShiftType shift, Reg m) {
-    if (n == Reg::PC || m == Reg::PC || s == Reg::PC || d == Reg::PC)
+    if (n == Reg::PC || m == Reg::PC || s == Reg::PC || d == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
-        auto carry_in = ir.GetCFlag();
-        auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
-        auto result = ir.SubWithCarry(ir.GetRegister(n), shifted.result, ir.GetCFlag());
-        ir.SetRegister(d, result.result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result.result));
-            ir.SetZFlag(ir.IsZero(result.result));
-            ir.SetCFlag(result.carry);
-            ir.SetVFlag(result.overflow);
-        }
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
+    const auto carry_in = ir.GetCFlag();
+    const auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
+    const auto result = ir.SubWithCarry(ir.GetRegister(n), shifted.result, ir.GetCFlag());
+
+    ir.SetRegister(d, result.result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result.result));
+        ir.SetZFlag(ir.IsZero(result.result));
+        ir.SetCFlag(result.carry);
+        ir.SetVFlag(result.overflow);
+    }
+
     return true;
 }
 
+// SUB{S}<c> <Rd>, <Rn>, #<const>
 bool ArmTranslatorVisitor::arm_SUB_imm(Cond cond, bool S, Reg n, Reg d, int rotate, Imm8 imm8) {
-    if (ConditionPassed(cond)) {
-        u32 imm32 = ArmExpandImm(rotate, imm8);
-        auto result = ir.SubWithCarry(ir.GetRegister(n), ir.Imm32(imm32), ir.Imm1(1));
-        if (d == Reg::PC) {
-            if (S) return UnpredictableInstruction(); // This is UNPREDICTABLE when in user-mode.
-            ir.ALUWritePC(result.result);
-            ir.SetTerm(IR::Term::ReturnToDispatch{});
-            return false;
-        }
-        ir.SetRegister(d, result.result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result.result));
-            ir.SetZFlag(ir.IsZero(result.result));
-            ir.SetCFlag(result.carry);
-            ir.SetVFlag(result.overflow);
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const u32 imm32 = ArmExpandImm(rotate, imm8);
+    const auto result = ir.SubWithCarry(ir.GetRegister(n), ir.Imm32(imm32), ir.Imm1(1));
+    if (d == Reg::PC) {
+        if (S) {
+            // This is UNPREDICTABLE when in user-mode.
+            return UnpredictableInstruction();
+        }
+
+        ir.ALUWritePC(result.result);
+        ir.SetTerm(IR::Term::ReturnToDispatch{});
+        return false;
+    }
+
+    ir.SetRegister(d, result.result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result.result));
+        ir.SetZFlag(ir.IsZero(result.result));
+        ir.SetCFlag(result.carry);
+        ir.SetVFlag(result.overflow);
+    }
+
     return true;
 }
 
+// SUB{S}<c> <Rd>, <Rn>, <Rm>{, <shift>}
 bool ArmTranslatorVisitor::arm_SUB_reg(Cond cond, bool S, Reg n, Reg d, Imm5 imm5, ShiftType shift, Reg m) {
-    if (ConditionPassed(cond)) {
-        auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, ir.GetCFlag());
-        auto result = ir.SubWithCarry(ir.GetRegister(n), shifted.result, ir.Imm1(1));
-        if (d == Reg::PC) {
-            if (S) return UnpredictableInstruction(); // This is UNPREDICTABLE when in user-mode.
-            ir.ALUWritePC(result.result);
-            ir.SetTerm(IR::Term::ReturnToDispatch{});
-            return false;
-        }
-        ir.SetRegister(d, result.result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result.result));
-            ir.SetZFlag(ir.IsZero(result.result));
-            ir.SetCFlag(result.carry);
-            ir.SetVFlag(result.overflow);
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, ir.GetCFlag());
+    const auto result = ir.SubWithCarry(ir.GetRegister(n), shifted.result, ir.Imm1(1));
+    if (d == Reg::PC) {
+        if (S) {
+            // This is UNPREDICTABLE when in user-mode.
+            return UnpredictableInstruction();
+        }
+
+        ir.ALUWritePC(result.result);
+        ir.SetTerm(IR::Term::ReturnToDispatch{});
+        return false;
+    }
+
+    ir.SetRegister(d, result.result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result.result));
+        ir.SetZFlag(ir.IsZero(result.result));
+        ir.SetCFlag(result.carry);
+        ir.SetVFlag(result.overflow);
+    }
+
     return true;
 }
 
 bool ArmTranslatorVisitor::arm_SUB_rsr(Cond cond, bool S, Reg n, Reg d, Reg s, ShiftType shift, Reg m) {
-    if (n == Reg::PC || m == Reg::PC || s == Reg::PC || d == Reg::PC)
+    if (n == Reg::PC || m == Reg::PC || s == Reg::PC || d == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
-        auto carry_in = ir.GetCFlag();
-        auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
-        auto result = ir.SubWithCarry(ir.GetRegister(n), shifted.result, ir.Imm1(1));
-        ir.SetRegister(d, result.result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result.result));
-            ir.SetZFlag(ir.IsZero(result.result));
-            ir.SetCFlag(result.carry);
-            ir.SetVFlag(result.overflow);
-        }
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
+    const auto carry_in = ir.GetCFlag();
+    const auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
+    const auto result = ir.SubWithCarry(ir.GetRegister(n), shifted.result, ir.Imm1(1));
+
+    ir.SetRegister(d, result.result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result.result));
+        ir.SetZFlag(ir.IsZero(result.result));
+        ir.SetCFlag(result.carry);
+        ir.SetVFlag(result.overflow);
+    }
+
     return true;
 }
 
+// TEQ<c> <Rn>, #<const>
 bool ArmTranslatorVisitor::arm_TEQ_imm(Cond cond, Reg n, int rotate, Imm8 imm8) {
-    if (ConditionPassed(cond)) {
-        auto imm_carry = ArmExpandImm_C(rotate, imm8, ir.GetCFlag());
-        auto result = ir.Eor(ir.GetRegister(n), ir.Imm32(imm_carry.imm32));
-        ir.SetNFlag(ir.MostSignificantBit(result));
-        ir.SetZFlag(ir.IsZero(result));
-        ir.SetCFlag(imm_carry.carry);
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto imm_carry = ArmExpandImm_C(rotate, imm8, ir.GetCFlag());
+    const auto result = ir.Eor(ir.GetRegister(n), ir.Imm32(imm_carry.imm32));
+
+    ir.SetNFlag(ir.MostSignificantBit(result));
+    ir.SetZFlag(ir.IsZero(result));
+    ir.SetCFlag(imm_carry.carry);
     return true;
 }
 
+// TEQ<c> <Rn>, <Rm>{, <shift>}
 bool ArmTranslatorVisitor::arm_TEQ_reg(Cond cond, Reg n, Imm5 imm5, ShiftType shift, Reg m) {
-    if (ConditionPassed(cond)) {
-        auto carry_in = ir.GetCFlag();
-        auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, carry_in);
-        auto result = ir.Eor(ir.GetRegister(n), shifted.result);
-        ir.SetNFlag(ir.MostSignificantBit(result));
-        ir.SetZFlag(ir.IsZero(result));
-        ir.SetCFlag(shifted.carry);
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto carry_in = ir.GetCFlag();
+    const auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, carry_in);
+    const auto result = ir.Eor(ir.GetRegister(n), shifted.result);
+
+    ir.SetNFlag(ir.MostSignificantBit(result));
+    ir.SetZFlag(ir.IsZero(result));
+    ir.SetCFlag(shifted.carry);
     return true;
 }
 
+// TEQ<c> <Rn>, <Rm>, <type> <Rs>
 bool ArmTranslatorVisitor::arm_TEQ_rsr(Cond cond, Reg n, Reg s, ShiftType shift, Reg m) {
-    if (n == Reg::PC || m == Reg::PC || s == Reg::PC)
+    if (n == Reg::PC || m == Reg::PC || s == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
-        auto carry_in = ir.GetCFlag();
-        auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
-        auto result = ir.Eor(ir.GetRegister(n), shifted.result);
-        ir.SetNFlag(ir.MostSignificantBit(result));
-        ir.SetZFlag(ir.IsZero(result));
-        ir.SetCFlag(shifted.carry);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
+    const auto carry_in = ir.GetCFlag();
+    const auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
+    const auto result = ir.Eor(ir.GetRegister(n), shifted.result);
+
+    ir.SetNFlag(ir.MostSignificantBit(result));
+    ir.SetZFlag(ir.IsZero(result));
+    ir.SetCFlag(shifted.carry);
     return true;
 }
 
+// TST<c> <Rn>, #<const>
 bool ArmTranslatorVisitor::arm_TST_imm(Cond cond, Reg n, int rotate, Imm8 imm8) {
-    if (ConditionPassed(cond)) {
-        auto imm_carry = ArmExpandImm_C(rotate, imm8, ir.GetCFlag());
-        auto result = ir.And(ir.GetRegister(n), ir.Imm32(imm_carry.imm32));
-        ir.SetNFlag(ir.MostSignificantBit(result));
-        ir.SetZFlag(ir.IsZero(result));
-        ir.SetCFlag(imm_carry.carry);
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto imm_carry = ArmExpandImm_C(rotate, imm8, ir.GetCFlag());
+    const auto result = ir.And(ir.GetRegister(n), ir.Imm32(imm_carry.imm32));
+
+    ir.SetNFlag(ir.MostSignificantBit(result));
+    ir.SetZFlag(ir.IsZero(result));
+    ir.SetCFlag(imm_carry.carry);
     return true;
 }
 
+// TST<c> <Rn>, <Rm>{, <shift>}
 bool ArmTranslatorVisitor::arm_TST_reg(Cond cond, Reg n, Imm5 imm5, ShiftType shift, Reg m) {
-    if (ConditionPassed(cond)) {
-        auto carry_in = ir.GetCFlag();
-        auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, carry_in);
-        auto result = ir.And(ir.GetRegister(n), shifted.result);
-        ir.SetNFlag(ir.MostSignificantBit(result));
-        ir.SetZFlag(ir.IsZero(result));
-        ir.SetCFlag(shifted.carry);
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto carry_in = ir.GetCFlag();
+    const auto shifted = EmitImmShift(ir.GetRegister(m), shift, imm5, carry_in);
+    const auto result = ir.And(ir.GetRegister(n), shifted.result);
+
+    ir.SetNFlag(ir.MostSignificantBit(result));
+    ir.SetZFlag(ir.IsZero(result));
+    ir.SetCFlag(shifted.carry);
     return true;
 }
 
+// TST<c> <Rn>, <Rm>, <type> <Rs>
 bool ArmTranslatorVisitor::arm_TST_rsr(Cond cond, Reg n, Reg s, ShiftType shift, Reg m) {
-    if (n == Reg::PC || m == Reg::PC || s == Reg::PC)
+    if (n == Reg::PC || m == Reg::PC || s == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
-        auto carry_in = ir.GetCFlag();
-        auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
-        auto result = ir.And(ir.GetRegister(n), shifted.result);
-        ir.SetNFlag(ir.MostSignificantBit(result));
-        ir.SetZFlag(ir.IsZero(result));
-        ir.SetCFlag(shifted.carry);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto shift_n = ir.LeastSignificantByte(ir.GetRegister(s));
+    const auto carry_in = ir.GetCFlag();
+    const auto shifted = EmitRegShift(ir.GetRegister(m), shift, shift_n, carry_in);
+    const auto result = ir.And(ir.GetRegister(n), shifted.result);
+
+    ir.SetNFlag(ir.MostSignificantBit(result));
+    ir.SetZFlag(ir.IsZero(result));
+    ir.SetCFlag(shifted.carry);
     return true;
 }
 

--- a/src/frontend/A32/translate/translate_arm/exception_generating.cpp
+++ b/src/frontend/A32/translate/translate_arm/exception_generating.cpp
@@ -10,33 +10,37 @@
 
 namespace Dynarmic::A32 {
 
+// BKPT #<imm16>
 bool ArmTranslatorVisitor::arm_BKPT(Cond cond, Imm12 /*imm12*/, Imm4 /*imm4*/) {
     if (cond != Cond::AL && !options.define_unpredictable_behaviour) {
         return UnpredictableInstruction();
     }
     // UNPREDICTABLE: The instruction executes conditionally.
 
-    if (ConditionPassed(cond)) {
-        ir.ExceptionRaised(Exception::Breakpoint);
-        ir.SetTerm(IR::Term::CheckHalt{IR::Term::ReturnToDispatch{}});
-        return false;
+    if (!ConditionPassed(cond)) {
+        return true;
     }
-    return true;
+
+    ir.ExceptionRaised(Exception::Breakpoint);
+    ir.SetTerm(IR::Term::CheckHalt{IR::Term::ReturnToDispatch{}});
+    return false;
 }
 
+// SVC<c> #<imm24>
 bool ArmTranslatorVisitor::arm_SVC(Cond cond, Imm24 imm24) {
-    u32 imm32 = imm24;
-    // SVC<c> #<imm24>
-    if (ConditionPassed(cond)) {
-        ir.PushRSB(ir.current_location.AdvancePC(4));
-        ir.BranchWritePC(ir.Imm32(ir.current_location.PC() + 4));
-        ir.CallSupervisor(ir.Imm32(imm32));
-        ir.SetTerm(IR::Term::CheckHalt{IR::Term::PopRSBHint{}});
-        return false;
+    if (!ConditionPassed(cond)) {
+        return true;
     }
-    return true;
+
+    const u32 imm32 = imm24;
+    ir.PushRSB(ir.current_location.AdvancePC(4));
+    ir.BranchWritePC(ir.Imm32(ir.current_location.PC() + 4));
+    ir.CallSupervisor(ir.Imm32(imm32));
+    ir.SetTerm(IR::Term::CheckHalt{IR::Term::PopRSBHint{}});
+    return false;
 }
 
+// UDF<c> #<imm16>
 bool ArmTranslatorVisitor::arm_UDF() {
     return UndefinedInstruction();
 }

--- a/src/frontend/A32/translate/translate_arm/extension.cpp
+++ b/src/frontend/A32/translate/translate_arm/extension.cpp
@@ -13,170 +13,217 @@ static IR::U32 Rotate(A32::IREmitter& ir, Reg m, SignExtendRotation rotate) {
     return ir.RotateRight(ir.GetRegister(m), ir.Imm8(rotate_by), ir.Imm1(0)).result;
 }
 
+// SXTAB<c> <Rd>, <Rn>, <Rm>{, <rotation>}
 bool ArmTranslatorVisitor::arm_SXTAB(Cond cond, Reg n, Reg d, SignExtendRotation rotate, Reg m) {
-    if (d == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    // SXTAB <Rd>, <Rn>, <Rm>, <rotate>
-    if (ConditionPassed(cond)) {
-        auto rotated = Rotate(ir, m, rotate);
-        auto reg_n = ir.GetRegister(n);
-        auto result = ir.Add(reg_n, ir.SignExtendByteToWord(ir.LeastSignificantByte(rotated)));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto rotated = Rotate(ir, m, rotate);
+    const auto reg_n = ir.GetRegister(n);
+    const auto result = ir.Add(reg_n, ir.SignExtendByteToWord(ir.LeastSignificantByte(rotated)));
+
+    ir.SetRegister(d, result);
     return true;
 }
 
+// SXTAB16<c> <Rd>, <Rn>, <Rm>{, <rotation>}
 bool ArmTranslatorVisitor::arm_SXTAB16(Cond cond, Reg n, Reg d, SignExtendRotation rotate, Reg m) {
-    if (d == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    // SXTAB16 <Rd>, <Rn>, <Rm>, <rotate>
-    if (ConditionPassed(cond)) {
-        auto rotated = Rotate(ir, m, rotate);
-        auto low_byte = ir.And(rotated, ir.Imm32(0x00FF00FF));
-        auto sign_bit = ir.And(rotated, ir.Imm32(0x00800080));
-        auto addend = ir.Or(low_byte, ir.Mul(sign_bit, ir.Imm32(0x1FE)));
-        auto result = ir.PackedAddU16(addend, ir.GetRegister(n)).result;
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto rotated = Rotate(ir, m, rotate);
+    const auto low_byte = ir.And(rotated, ir.Imm32(0x00FF00FF));
+    const auto sign_bit = ir.And(rotated, ir.Imm32(0x00800080));
+    const auto addend = ir.Or(low_byte, ir.Mul(sign_bit, ir.Imm32(0x1FE)));
+    const auto result = ir.PackedAddU16(addend, ir.GetRegister(n)).result;
+
+    ir.SetRegister(d, result);
     return true;
 }
 
+// SXTAH<c> <Rd>, <Rn>, <Rm>{, <rotation>}
 bool ArmTranslatorVisitor::arm_SXTAH(Cond cond, Reg n, Reg d, SignExtendRotation rotate, Reg m) {
-    if (d == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    // SXTAH <Rd>, <Rn>, <Rm>, <rotate>
-    if (ConditionPassed(cond)) {
-        auto rotated = Rotate(ir, m, rotate);
-        auto reg_n = ir.GetRegister(n);
-        auto result = ir.Add(reg_n, ir.SignExtendHalfToWord(ir.LeastSignificantHalf(rotated)));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto rotated = Rotate(ir, m, rotate);
+    const auto reg_n = ir.GetRegister(n);
+    const auto result = ir.Add(reg_n, ir.SignExtendHalfToWord(ir.LeastSignificantHalf(rotated)));
+
+    ir.SetRegister(d, result);
     return true;
 }
 
+// SXTB<c> <Rd>, <Rm>{, <rotation>}
 bool ArmTranslatorVisitor::arm_SXTB(Cond cond, Reg d, SignExtendRotation rotate, Reg m) {
-    if (d == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    // SXTB <Rd>, <Rm>, <rotate>
-    if (ConditionPassed(cond)) {
-        auto rotated = Rotate(ir, m, rotate);
-        auto result = ir.SignExtendByteToWord(ir.LeastSignificantByte(rotated));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto rotated = Rotate(ir, m, rotate);
+    const auto result = ir.SignExtendByteToWord(ir.LeastSignificantByte(rotated));
+
+    ir.SetRegister(d, result);
     return true;
 }
 
+// SXTB16<c> <Rd>, <Rm>{, <rotation>}
 bool ArmTranslatorVisitor::arm_SXTB16(Cond cond, Reg d, SignExtendRotation rotate, Reg m) {
-    if (d == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    // SXTB16 <Rd>, <Rm>, <rotate>
-    if (ConditionPassed(cond)) {
-        auto rotated = Rotate(ir, m, rotate);
-        auto low_byte = ir.And(rotated, ir.Imm32(0x00FF00FF));
-        auto sign_bit = ir.And(rotated, ir.Imm32(0x00800080));
-        auto result = ir.Or(low_byte, ir.Mul(sign_bit, ir.Imm32(0x1FE)));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto rotated = Rotate(ir, m, rotate);
+    const auto low_byte = ir.And(rotated, ir.Imm32(0x00FF00FF));
+    const auto sign_bit = ir.And(rotated, ir.Imm32(0x00800080));
+    const auto result = ir.Or(low_byte, ir.Mul(sign_bit, ir.Imm32(0x1FE)));
+
+    ir.SetRegister(d, result);
     return true;
 }
 
+// SXTH<c> <Rd>, <Rm>{, <rotation>}
 bool ArmTranslatorVisitor::arm_SXTH(Cond cond, Reg d, SignExtendRotation rotate, Reg m) {
-    if (d == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    // SXTH <Rd>, <Rm>, <rotate>
-    if (ConditionPassed(cond)) {
-        auto rotated = Rotate(ir, m, rotate);
-        auto result = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(rotated));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto rotated = Rotate(ir, m, rotate);
+    const auto result = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(rotated));
+
+    ir.SetRegister(d, result);
     return true;
 }
 
+// UXTAB<c> <Rd>, <Rn>, <Rm>{, <rotation>}
 bool ArmTranslatorVisitor::arm_UXTAB(Cond cond, Reg n, Reg d, SignExtendRotation rotate, Reg m) {
-    if (d == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    // UXTAB <Rd>, <Rn>, <Rm>, <rotate>
-    if (ConditionPassed(cond)) {
-        auto rotated = Rotate(ir, m, rotate);
-        auto reg_n = ir.GetRegister(n);
-        auto result = ir.Add(reg_n, ir.ZeroExtendByteToWord(ir.LeastSignificantByte(rotated)));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto rotated = Rotate(ir, m, rotate);
+    const auto reg_n = ir.GetRegister(n);
+    const auto result = ir.Add(reg_n, ir.ZeroExtendByteToWord(ir.LeastSignificantByte(rotated)));
+
+    ir.SetRegister(d, result);
     return true;
 }
 
+// UXTAB16<c> <Rd>, <Rn>, <Rm>{, <rotation>}
 bool ArmTranslatorVisitor::arm_UXTAB16(Cond cond, Reg n, Reg d, SignExtendRotation rotate, Reg m) {
-    if (d == Reg::PC || m == Reg::PC || n == Reg::PC)
+    if (d == Reg::PC || m == Reg::PC || n == Reg::PC) {
         return UnpredictableInstruction();
-
-    // UXTAB16 <Rd>, <Rn>, <Rm>, <rotate>
-    if (ConditionPassed(cond)) {
-        auto rotated = Rotate(ir, m, rotate);
-        auto result = ir.And(rotated, ir.Imm32(0x00FF00FF));
-        auto reg_n = ir.GetRegister(n);
-        result = ir.PackedAddU16(reg_n, result).result;
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto rotated = Rotate(ir, m, rotate);
+    auto result = ir.And(rotated, ir.Imm32(0x00FF00FF));
+    const auto reg_n = ir.GetRegister(n);
+    result = ir.PackedAddU16(reg_n, result).result;
+
+    ir.SetRegister(d, result);
     return true;
 }
 
+// UXTAH<c> <Rd>, <Rn>, <Rm>{, <rotation>}
 bool ArmTranslatorVisitor::arm_UXTAH(Cond cond, Reg n, Reg d, SignExtendRotation rotate, Reg m) {
-    if (d == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    // UXTAH <Rd>, <Rn>, <Rm>, <rotate>
-    if (ConditionPassed(cond)) {
-        auto rotated = Rotate(ir, m, rotate);
-        auto reg_n = ir.GetRegister(n);
-        auto result = ir.Add(reg_n, ir.ZeroExtendHalfToWord(ir.LeastSignificantHalf(rotated)));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto rotated = Rotate(ir, m, rotate);
+    const auto reg_n = ir.GetRegister(n);
+    const auto result = ir.Add(reg_n, ir.ZeroExtendHalfToWord(ir.LeastSignificantHalf(rotated)));
+
+    ir.SetRegister(d, result);
     return true;
 }
 
+// UXTB<c> <Rd>, <Rm>{, <rotation>}
 bool ArmTranslatorVisitor::arm_UXTB(Cond cond, Reg d, SignExtendRotation rotate, Reg m) {
-    if (d == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    // UXTB <Rd>, <Rm>, <rotate>
-    if (ConditionPassed(cond)) {
-        auto rotated = Rotate(ir, m, rotate);
-        auto result = ir.ZeroExtendByteToWord(ir.LeastSignificantByte(rotated));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto rotated = Rotate(ir, m, rotate);
+    const auto result = ir.ZeroExtendByteToWord(ir.LeastSignificantByte(rotated));
+    ir.SetRegister(d, result);
     return true;
 }
 
+// UXTB16<c> <Rd>, <Rm>{, <rotation>}
 bool ArmTranslatorVisitor::arm_UXTB16(Cond cond, Reg d, SignExtendRotation rotate, Reg m) {
-    if (d == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    // UXTB16 <Rd>, <Rm>, <rotate>
-    if (ConditionPassed(cond)) {
-        auto rotated = Rotate(ir, m, rotate);
-        auto result = ir.And(rotated, ir.Imm32(0x00FF00FF));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto rotated = Rotate(ir, m, rotate);
+    const auto result = ir.And(rotated, ir.Imm32(0x00FF00FF));
+
+    ir.SetRegister(d, result);
     return true;
 }
 
+// UXTH<c> <Rd>, <Rm>{, <rotation>}
 bool ArmTranslatorVisitor::arm_UXTH(Cond cond, Reg d, SignExtendRotation rotate, Reg m) {
-    if (d == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    // UXTH <Rd>, <Rm>, <rotate>
-    if (ConditionPassed(cond)) {
-        auto rotated = Rotate(ir, m, rotate);
-        auto result = ir.ZeroExtendHalfToWord(ir.LeastSignificantHalf(rotated));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto rotated = Rotate(ir, m, rotate);
+    const auto result = ir.ZeroExtendHalfToWord(ir.LeastSignificantHalf(rotated));
+
+    ir.SetRegister(d, result);
     return true;
 }
 

--- a/src/frontend/A32/translate/translate_arm/load_store.cpp
+++ b/src/frontend/A32/translate/translate_arm/load_store.cpp
@@ -55,555 +55,689 @@ static IR::U32 GetAddress(A32::IREmitter& ir, bool P, bool U, bool W, Reg n, IR:
     return address;
 }
 
+// LDR <Rt>, [PC, #+/-<imm>]
 bool ArmTranslatorVisitor::arm_LDR_lit(Cond cond, bool U, Reg t, Imm12 imm12) {
-    const bool add = U;
-
-    // LDR <Rt>, [PC, #+/-<imm>]
-    if (ConditionPassed(cond)) {
-        const u32 base = ir.AlignPC(4);
-        const u32 address = add ? (base + imm12) : (base - imm12);
-        const auto data = ir.ReadMemory32(ir.Imm32(address));
-
-        if (t == Reg::PC) {
-            ir.LoadWritePC(data);
-            ir.SetTerm(IR::Term::FastDispatchHint{});
-            return false;
-        }
-
-        ir.SetRegister(t, data);
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const bool add = U;
+    const u32 base = ir.AlignPC(4);
+    const u32 address = add ? (base + imm12) : (base - imm12);
+    const auto data = ir.ReadMemory32(ir.Imm32(address));
+
+    if (t == Reg::PC) {
+        ir.LoadWritePC(data);
+        ir.SetTerm(IR::Term::FastDispatchHint{});
+        return false;
+    }
+
+    ir.SetRegister(t, data);
     return true;
 }
 
+// LDR <Rt>, [<Rn>, #+/-<imm>]{!}
+// LDR <Rt>, [<Rn>], #+/-<imm>
 bool ArmTranslatorVisitor::arm_LDR_imm(Cond cond, bool P, bool U, bool W, Reg n, Reg t, Imm12 imm12) {
-    if (n == Reg::PC)
+    if (n == Reg::PC) {
         return UnpredictableInstruction();
+    }
+
     ASSERT_MSG(!(!P && W), "T form of instruction unimplemented");
-    if ((!P || W) && n == t)
+    if ((!P || W) && n == t) {
         return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
 
     const u32 imm32 = imm12;
+    const auto offset = ir.Imm32(imm32);
+    const auto address = GetAddress(ir, P, U, W, n, offset);
+    const auto data = ir.ReadMemory32(address);
 
-    // LDR <Rt>, [<Rn>, #+/-<imm>]{!}
-    // LDR <Rt>, [<Rn>], #+/-<imm>
-    if (ConditionPassed(cond)) {
-        const auto offset = ir.Imm32(imm32);
-        const auto address = GetAddress(ir, P, U, W, n, offset);
-        const auto data = ir.ReadMemory32(address);
+    if (t == Reg::PC) {
+        ir.LoadWritePC(data);
 
-        if (t == Reg::PC) {
-            ir.LoadWritePC(data);
-            if (!P && W && n == Reg::R13)
-                ir.SetTerm(IR::Term::PopRSBHint{});
-            else
-                ir.SetTerm(IR::Term::FastDispatchHint{});
-            return false;
+        if (!P && W && n == Reg::R13) {
+            ir.SetTerm(IR::Term::PopRSBHint{});
+        } else {
+            ir.SetTerm(IR::Term::FastDispatchHint{});
         }
 
-        ir.SetRegister(t, data);
+        return false;
     }
+
+    ir.SetRegister(t, data);
     return true;
 }
 
+// LDR <Rt>, [<Rn>, #+/-<Rm>]{!}
+// LDR <Rt>, [<Rn>], #+/-<Rm>
 bool ArmTranslatorVisitor::arm_LDR_reg(Cond cond, bool P, bool U, bool W, Reg n, Reg t, Imm5 imm5, ShiftType shift, Reg m) {
     ASSERT_MSG(!(!P && W), "T form of instruction unimplemented");
-    if (m == Reg::PC)
+    if (m == Reg::PC) {
         return UnpredictableInstruction();
-    if ((!P || W) && (n == Reg::PC || n == t))
-        return UnpredictableInstruction();
-
-    // LDR <Rt>, [<Rn>, #+/-<Rm>]{!}
-    // LDR <Rt>, [<Rn>], #+/-<Rm>
-    if (ConditionPassed(cond)) {
-        const auto offset = EmitImmShift(ir.GetRegister(m), shift, imm5, ir.GetCFlag()).result;
-        const auto address = GetAddress(ir, P, U, W, n, offset);
-        const auto data = ir.ReadMemory32(address);
-
-        if (t == Reg::PC) {
-            ir.LoadWritePC(data);
-            ir.SetTerm(IR::Term::FastDispatchHint{});
-            return false;
-        }
-
-        ir.SetRegister(t, data);
     }
+
+    if ((!P || W) && (n == Reg::PC || n == t)) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto offset = EmitImmShift(ir.GetRegister(m), shift, imm5, ir.GetCFlag()).result;
+    const auto address = GetAddress(ir, P, U, W, n, offset);
+    const auto data = ir.ReadMemory32(address);
+
+    if (t == Reg::PC) {
+        ir.LoadWritePC(data);
+        ir.SetTerm(IR::Term::FastDispatchHint{});
+        return false;
+    }
+
+    ir.SetRegister(t, data);
     return true;
 }
 
+// LDRB <Rt>, [PC, #+/-<imm>]
 bool ArmTranslatorVisitor::arm_LDRB_lit(Cond cond, bool U, Reg t, Imm12 imm12) {
-    if (t == Reg::PC)
+    if (t == Reg::PC) {
         return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
 
     const u32 imm32 = imm12;
     const bool add = U;
+    const u32 base = ir.AlignPC(4);
+    const u32 address = add ? (base + imm32) : (base - imm32);
+    const auto data = ir.ZeroExtendByteToWord(ir.ReadMemory8(ir.Imm32(address)));
 
-    // LDRB <Rt>, [PC, #+/-<imm>]
-    if (ConditionPassed(cond)) {
-        const u32 base = ir.AlignPC(4);
-        const u32 address = add ? (base + imm32) : (base - imm32);
-        const auto data = ir.ZeroExtendByteToWord(ir.ReadMemory8(ir.Imm32(address)));
-
-        ir.SetRegister(t, data);
-    }
+    ir.SetRegister(t, data);
     return true;
 }
 
+// LDRB <Rt>, [<Rn>, #+/-<imm>]{!}
+// LDRB <Rt>, [<Rn>], #+/-<imm>
 bool ArmTranslatorVisitor::arm_LDRB_imm(Cond cond, bool P, bool U, bool W, Reg n, Reg t, Imm12 imm12) {
-    if (n == Reg::PC)
+    if (n == Reg::PC) {
         return UnpredictableInstruction();
+    }
+
     ASSERT_MSG(!(!P && W), "T form of instruction unimplemented");
-    if ((!P || W) && n == t)
+    if ((!P || W) && n == t) {
         return UnpredictableInstruction();
-    if (t == Reg::PC)
+    }
+
+    if (t == Reg::PC) {
         return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
 
     const u32 imm32 = imm12;
+    const auto offset = ir.Imm32(imm32);
+    const auto address = GetAddress(ir, P, U, W, n, offset);
+    const auto data = ir.ZeroExtendByteToWord(ir.ReadMemory8(address));
 
-    // LDRB <Rt>, [<Rn>, #+/-<imm>]{!}
-    // LDRB <Rt>, [<Rn>], #+/-<imm>
-    if (ConditionPassed(cond)) {
-        const auto offset = ir.Imm32(imm32);
-        const auto address = GetAddress(ir, P, U, W, n, offset);
-        const auto data = ir.ZeroExtendByteToWord(ir.ReadMemory8(address));
-
-        ir.SetRegister(t, data);
-    }
+    ir.SetRegister(t, data);
     return true;
 }
 
+// LDRB <Rt>, [<Rn>, #+/-<Rm>]{!}
+// LDRB <Rt>, [<Rn>], #+/-<Rm>
 bool ArmTranslatorVisitor::arm_LDRB_reg(Cond cond, bool P, bool U, bool W, Reg n, Reg t, Imm5 imm5, ShiftType shift, Reg m) {
     ASSERT_MSG(!(!P && W), "T form of instruction unimplemented");
-    if (t == Reg::PC || m == Reg::PC)
+    if (t == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if ((!P || W) && (n == Reg::PC || n == t))
-        return UnpredictableInstruction();
-
-    // LDRB <Rt>, [<Rn>, #+/-<Rm>]{!}
-    // LDRB <Rt>, [<Rn>], #+/-<Rm>
-    if (ConditionPassed(cond)) {
-        const auto offset = EmitImmShift(ir.GetRegister(m), shift, imm5, ir.GetCFlag()).result;
-        const auto address = GetAddress(ir, P, U, W, n, offset);
-        const auto data = ir.ZeroExtendByteToWord(ir.ReadMemory8(address));
-
-        ir.SetRegister(t, data);
     }
+
+    if ((!P || W) && (n == Reg::PC || n == t)) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto offset = EmitImmShift(ir.GetRegister(m), shift, imm5, ir.GetCFlag()).result;
+    const auto address = GetAddress(ir, P, U, W, n, offset);
+    const auto data = ir.ZeroExtendByteToWord(ir.ReadMemory8(address));
+
+    ir.SetRegister(t, data);
     return true;
 }
 
+// LDRD <Rt>, <Rt2>, [PC, #+/-<imm>]
 bool ArmTranslatorVisitor::arm_LDRD_lit(Cond cond, bool U, Reg t, Imm4 imm8a, Imm4 imm8b) {
-    if (RegNumber(t) % 2 == 1)
+    if (RegNumber(t) % 2 == 1) {
         return UnpredictableInstruction();
-    if (t+1 == Reg::PC)
+    }
+
+    if (t+1 == Reg::PC) {
         return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
 
     const Reg t2 = t+1;
     const u32 imm32 = (imm8a << 4) | imm8b;
     const bool add = U;
 
-    // LDRD <Rt>, <Rt2>, [PC, #+/-<imm>]
-    if (ConditionPassed(cond)) {
-        const u32 base = ir.AlignPC(4);
-        const u32 address = add ? (base + imm32) : (base - imm32);
-        const auto data_a = ir.ReadMemory32(ir.Imm32(address));
-        const auto data_b = ir.ReadMemory32(ir.Imm32(address + 4));
+    const u32 base = ir.AlignPC(4);
+    const u32 address = add ? (base + imm32) : (base - imm32);
+    const auto data_a = ir.ReadMemory32(ir.Imm32(address));
+    const auto data_b = ir.ReadMemory32(ir.Imm32(address + 4));
 
-        ir.SetRegister(t, data_a);
-        ir.SetRegister(t2, data_b);
-    }
+    ir.SetRegister(t, data_a);
+    ir.SetRegister(t2, data_b);
     return true;
 }
 
+// LDRD <Rt>, [<Rn>, #+/-<imm>]{!}
+// LDRD <Rt>, [<Rn>], #+/-<imm>
 bool ArmTranslatorVisitor::arm_LDRD_imm(Cond cond, bool P, bool U, bool W, Reg n, Reg t, Imm4 imm8a, Imm4 imm8b) {
-    if (n == Reg::PC)
+    if (n == Reg::PC) {
         return UnpredictableInstruction();
-    if (RegNumber(t) % 2 == 1)
+    }
+
+    if (RegNumber(t) % 2 == 1) {
         return UnpredictableInstruction();
-    if (!P && W)
+    }
+
+    if (!P && W) {
         return UnpredictableInstruction();
-    if ((!P || W) && (n == t || n == t+1))
+    }
+
+    if ((!P || W) && (n == t || n == t+1)) {
         return UnpredictableInstruction();
-    if (t+1 == Reg::PC)
+    }
+
+    if (t+1 == Reg::PC) {
         return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
 
     const Reg t2 = t+1;
     const u32 imm32 = (imm8a << 4) | imm8b;
 
-    // LDRD <Rt>, [<Rn>, #+/-<imm>]{!}
-    // LDRD <Rt>, [<Rn>], #+/-<imm>
-    if (ConditionPassed(cond)) {
-        const auto offset = ir.Imm32(imm32);
-        const auto address_a = GetAddress(ir, P, U, W, n, offset);
-        const auto address_b = ir.Add(address_a, ir.Imm32(4));
-        const auto data_a = ir.ReadMemory32(address_a);
-        const auto data_b = ir.ReadMemory32(address_b);
+    const auto offset = ir.Imm32(imm32);
+    const auto address_a = GetAddress(ir, P, U, W, n, offset);
+    const auto address_b = ir.Add(address_a, ir.Imm32(4));
+    const auto data_a = ir.ReadMemory32(address_a);
+    const auto data_b = ir.ReadMemory32(address_b);
 
-        ir.SetRegister(t, data_a);
-        ir.SetRegister(t2, data_b);
-    }
+    ir.SetRegister(t, data_a);
+    ir.SetRegister(t2, data_b);
     return true;
 }
 
+// LDRD <Rt>, [<Rn>, #+/-<Rm>]{!}
+// LDRD <Rt>, [<Rn>], #+/-<Rm>
 bool ArmTranslatorVisitor::arm_LDRD_reg(Cond cond, bool P, bool U, bool W, Reg n, Reg t, Reg m) {
-    if (RegNumber(t) % 2 == 1)
+    if (RegNumber(t) % 2 == 1) {
         return UnpredictableInstruction();
-    if (!P && W)
+    }
+
+    if (!P && W) {
         return UnpredictableInstruction();
-    if (t+1 == Reg::PC || m == Reg::PC || m == t || m == t+1)
+    }
+
+    if (t+1 == Reg::PC || m == Reg::PC || m == t || m == t+1) {
         return UnpredictableInstruction();
-    if ((!P || W) && (n == Reg::PC || n == t || n == t+1))
+    }
+
+    if ((!P || W) && (n == Reg::PC || n == t || n == t+1)) {
         return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
 
     const Reg t2 = t+1;
+    const auto offset = ir.GetRegister(m);
+    const auto address_a = GetAddress(ir, P, U, W, n, offset);
+    const auto address_b = ir.Add(address_a, ir.Imm32(4));
+    const auto data_a = ir.ReadMemory32(address_a);
+    const auto data_b = ir.ReadMemory32(address_b);
 
-    // LDRD <Rt>, [<Rn>, #+/-<Rm>]{!}
-    // LDRD <Rt>, [<Rn>], #+/-<Rm>
-    if (ConditionPassed(cond)) {
-        const auto offset = ir.GetRegister(m);
-        const auto address_a = GetAddress(ir, P, U, W, n, offset);
-        const auto address_b = ir.Add(address_a, ir.Imm32(4));
-        const auto data_a = ir.ReadMemory32(address_a);
-        const auto data_b = ir.ReadMemory32(address_b);
-
-        ir.SetRegister(t, data_a);
-        ir.SetRegister(t2, data_b);
-    }
+    ir.SetRegister(t, data_a);
+    ir.SetRegister(t2, data_b);
     return true;
 }
 
+// LDRH <Rt>, [PC, #-/+<imm>]
 bool ArmTranslatorVisitor::arm_LDRH_lit(Cond cond, bool P, bool U, bool W, Reg t, Imm4 imm8a, Imm4 imm8b) {
     ASSERT_MSG(!(!P && W), "T form of instruction unimplemented");
-    if (P == W)
+    if (P == W) {
         return UnpredictableInstruction();
-    if (t == Reg::PC)
+    }
+
+    if (t == Reg::PC) {
         return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
 
     const u32 imm32 = (imm8a << 4) | imm8b;
     const bool add = U;
+    const u32 base = ir.AlignPC(4);
+    const u32 address = add ? (base + imm32) : (base - imm32);
+    const auto data = ir.ZeroExtendHalfToWord(ir.ReadMemory16(ir.Imm32(address)));
 
-    // LDRH <Rt>, [PC, #-/+<imm>]
-    if (ConditionPassed(cond)) {
-        const u32 base = ir.AlignPC(4);
-        const u32 address = add ? (base + imm32) : (base - imm32);
-        const auto data = ir.ZeroExtendHalfToWord(ir.ReadMemory16(ir.Imm32(address)));
-
-        ir.SetRegister(t, data);
-    }
+    ir.SetRegister(t, data);
     return true;
 }
 
+// LDRH <Rt>, [<Rn>, #+/-<imm>]{!}
+// LDRH <Rt>, [<Rn>], #+/-<imm>
 bool ArmTranslatorVisitor::arm_LDRH_imm(Cond cond, bool P, bool U, bool W, Reg n, Reg t, Imm4 imm8a, Imm4 imm8b) {
-    if (n == Reg::PC)
+    if (n == Reg::PC) {
         return UnpredictableInstruction();
+    }
+
     ASSERT_MSG(!(!P && W), "T form of instruction unimplemented");
-    if ((!P || W) && n == t)
+    if ((!P || W) && n == t) {
         return UnpredictableInstruction();
-    if (t == Reg::PC)
+    }
+
+    if (t == Reg::PC) {
         return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
 
     const u32 imm32 = (imm8a << 4) | imm8b;
+    const auto offset = ir.Imm32(imm32);
+    const auto address = GetAddress(ir, P, U, W, n, offset);
+    const auto data = ir.ZeroExtendHalfToWord(ir.ReadMemory16(address));
 
-    // LDRH <Rt>, [<Rn>, #+/-<imm>]{!}
-    // LDRH <Rt>, [<Rn>], #+/-<imm>
-    if (ConditionPassed(cond)) {
-        const auto offset = ir.Imm32(imm32);
-        const auto address = GetAddress(ir, P, U, W, n, offset);
-        const auto data = ir.ZeroExtendHalfToWord(ir.ReadMemory16(address));
-
-        ir.SetRegister(t, data);
-    }
+    ir.SetRegister(t, data);
     return true;
 }
 
+// LDRH <Rt>, [<Rn>, #+/-<Rm>]{!}
+// LDRH <Rt>, [<Rn>], #+/-<Rm>
 bool ArmTranslatorVisitor::arm_LDRH_reg(Cond cond, bool P, bool U, bool W, Reg n, Reg t, Reg m) {
     ASSERT_MSG(!(!P && W), "T form of instruction unimplemented");
-    if (t == Reg::PC || m == Reg::PC)
+    if (t == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if ((!P || W) && (n == Reg::PC || n == t))
-        return UnpredictableInstruction();
-
-    // LDRH <Rt>, [<Rn>, #+/-<Rm>]{!}
-    // LDRH <Rt>, [<Rn>], #+/-<Rm>
-    if (ConditionPassed(cond)) {
-        const auto offset = ir.GetRegister(m);
-        const auto address = GetAddress(ir, P, U, W, n, offset);
-        const auto data = ir.ZeroExtendHalfToWord(ir.ReadMemory16(address));
-
-        ir.SetRegister(t, data);
     }
+
+    if ((!P || W) && (n == Reg::PC || n == t)) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto offset = ir.GetRegister(m);
+    const auto address = GetAddress(ir, P, U, W, n, offset);
+    const auto data = ir.ZeroExtendHalfToWord(ir.ReadMemory16(address));
+
+    ir.SetRegister(t, data);
     return true;
 }
 
+// LDRSB <Rt>, [PC, #+/-<imm>]
 bool ArmTranslatorVisitor::arm_LDRSB_lit(Cond cond, bool U, Reg t, Imm4 imm8a, Imm4 imm8b) {
-    if (t == Reg::PC)
+    if (t == Reg::PC) {
         return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
 
     const u32 imm32 = (imm8a << 4) | imm8b;
     const bool add = U;
 
-    // LDRSB <Rt>, [PC, #+/-<imm>]
-    if (ConditionPassed(cond)) {
-        const u32 base = ir.AlignPC(4);
-        const u32 address = add ? (base + imm32) : (base - imm32);
-        const auto data = ir.SignExtendByteToWord(ir.ReadMemory8(ir.Imm32(address)));
+    const u32 base = ir.AlignPC(4);
+    const u32 address = add ? (base + imm32) : (base - imm32);
+    const auto data = ir.SignExtendByteToWord(ir.ReadMemory8(ir.Imm32(address)));
 
-        ir.SetRegister(t, data);
-    }
+    ir.SetRegister(t, data);
     return true;
 }
 
+// LDRSB <Rt>, [<Rn>, #+/-<imm>]{!}
+// LDRSB <Rt>, [<Rn>], #+/-<imm>
 bool ArmTranslatorVisitor::arm_LDRSB_imm(Cond cond, bool P, bool U, bool W, Reg n, Reg t, Imm4 imm8a, Imm4 imm8b) {
-    if (n == Reg::PC)
+    if (n == Reg::PC) {
         return UnpredictableInstruction();
+    }
+
     ASSERT_MSG(!(!P && W), "T form of instruction unimplemented");
-    if ((!P || W) && n == t)
+    if ((!P || W) && n == t) {
         return UnpredictableInstruction();
-    if (t == Reg::PC)
+    }
+
+    if (t == Reg::PC) {
         return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
 
     const u32 imm32 = (imm8a << 4) | imm8b;
+    const auto offset = ir.Imm32(imm32);
+    const auto address = GetAddress(ir, P, U, W, n, offset);
+    const auto data = ir.SignExtendByteToWord(ir.ReadMemory8(address));
 
-    // LDRSB <Rt>, [<Rn>, #+/-<imm>]{!}
-    // LDRSB <Rt>, [<Rn>], #+/-<imm>
-    if (ConditionPassed(cond)) {
-        const auto offset = ir.Imm32(imm32);
-        const auto address = GetAddress(ir, P, U, W, n, offset);
-        const auto data = ir.SignExtendByteToWord(ir.ReadMemory8(address));
-
-        ir.SetRegister(t, data);
-    }
+    ir.SetRegister(t, data);
     return true;
 }
 
+// LDRSB <Rt>, [<Rn>, #+/-<Rm>]{!}
+// LDRSB <Rt>, [<Rn>], #+/-<Rm>
 bool ArmTranslatorVisitor::arm_LDRSB_reg(Cond cond, bool P, bool U, bool W, Reg n, Reg t, Reg m) {
     ASSERT_MSG(!(!P && W), "T form of instruction unimplemented");
-    if (t == Reg::PC || m == Reg::PC)
+    if (t == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if ((!P || W) && (n == Reg::PC || n == t))
-        return UnpredictableInstruction();
-
-    // LDRSB <Rt>, [<Rn>, #+/-<Rm>]{!}
-    // LDRSB <Rt>, [<Rn>], #+/-<Rm>
-    if (ConditionPassed(cond)) {
-        const auto offset = ir.GetRegister(m);
-        const auto address = GetAddress(ir, P, U, W, n, offset);
-        const auto data = ir.SignExtendByteToWord(ir.ReadMemory8(address));
-
-        ir.SetRegister(t, data);
     }
+
+    if ((!P || W) && (n == Reg::PC || n == t)) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto offset = ir.GetRegister(m);
+    const auto address = GetAddress(ir, P, U, W, n, offset);
+    const auto data = ir.SignExtendByteToWord(ir.ReadMemory8(address));
+
+    ir.SetRegister(t, data);
     return true;
 }
 
+// LDRSH <Rt>, [PC, #-/+<imm>]
 bool ArmTranslatorVisitor::arm_LDRSH_lit(Cond cond, bool U, Reg t, Imm4 imm8a, Imm4 imm8b) {
-    if (t == Reg::PC)
+    if (t == Reg::PC) {
         return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
 
     const u32 imm32 = (imm8a << 4) | imm8b;
     const bool add = U;
+    const u32 base = ir.AlignPC(4);
+    const u32 address = add ? (base + imm32) : (base - imm32);
+    const auto data = ir.SignExtendHalfToWord(ir.ReadMemory16(ir.Imm32(address)));
 
-    // LDRSH <Rt>, [PC, #-/+<imm>]
-    if (ConditionPassed(cond)) {
-        const u32 base = ir.AlignPC(4);
-        const u32 address = add ? (base + imm32) : (base - imm32);
-        const auto data = ir.SignExtendHalfToWord(ir.ReadMemory16(ir.Imm32(address)));
-
-        ir.SetRegister(t, data);
-    }
+    ir.SetRegister(t, data);
     return true;
 }
 
+// LDRSH <Rt>, [<Rn>, #+/-<imm>]{!}
+// LDRSH <Rt>, [<Rn>], #+/-<imm>
 bool ArmTranslatorVisitor::arm_LDRSH_imm(Cond cond, bool P, bool U, bool W, Reg n, Reg t, Imm4 imm8a, Imm4 imm8b) {
-    if (n == Reg::PC)
+    if (n == Reg::PC) {
         return UnpredictableInstruction();
+    }
+
     ASSERT_MSG(!(!P && W), "T form of instruction unimplemented");
-    if ((!P || W) && n == t)
+    if ((!P || W) && n == t) {
         return UnpredictableInstruction();
-    if (t == Reg::PC)
+    }
+
+    if (t == Reg::PC) {
         return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
 
     const u32 imm32 = (imm8a << 4) | imm8b;
+    const auto offset = ir.Imm32(imm32);
+    const auto address = GetAddress(ir, P, U, W, n, offset);
+    const auto data = ir.SignExtendHalfToWord(ir.ReadMemory16(address));
 
-    // LDRSH <Rt>, [<Rn>, #+/-<imm>]{!}
-    // LDRSH <Rt>, [<Rn>], #+/-<imm>
-    if (ConditionPassed(cond)) {
-        const auto offset = ir.Imm32(imm32);
-        const auto address = GetAddress(ir, P, U, W, n, offset);
-        const auto data = ir.SignExtendHalfToWord(ir.ReadMemory16(address));
-
-        ir.SetRegister(t, data);
-    }
+    ir.SetRegister(t, data);
     return true;
 }
 
+// LDRSH <Rt>, [<Rn>, #+/-<Rm>]{!}
+// LDRSH <Rt>, [<Rn>], #+/-<Rm>
 bool ArmTranslatorVisitor::arm_LDRSH_reg(Cond cond, bool P, bool U, bool W, Reg n, Reg t, Reg m) {
     ASSERT_MSG(!(!P && W), "T form of instruction unimplemented");
-    if (t == Reg::PC || m == Reg::PC)
+    if (t == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if ((!P || W) && (n == Reg::PC || n == t))
-        return UnpredictableInstruction();
-
-    // LDRSH <Rt>, [<Rn>, #+/-<Rm>]{!}
-    // LDRSH <Rt>, [<Rn>], #+/-<Rm>
-    if (ConditionPassed(cond)) {
-        const auto offset = ir.GetRegister(m);
-        const auto address = GetAddress(ir, P, U, W, n, offset);
-        const auto data = ir.SignExtendHalfToWord(ir.ReadMemory16(address));
-
-        ir.SetRegister(t, data);
     }
+
+    if ((!P || W) && (n == Reg::PC || n == t)) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto offset = ir.GetRegister(m);
+    const auto address = GetAddress(ir, P, U, W, n, offset);
+    const auto data = ir.SignExtendHalfToWord(ir.ReadMemory16(address));
+
+    ir.SetRegister(t, data);
     return true;
 }
 
+// STR <Rt>, [<Rn>, #+/-<imm>]{!}
+// STR <Rt>, [<Rn>], #+/-<imm>
 bool ArmTranslatorVisitor::arm_STR_imm(Cond cond, bool P, bool U, bool W, Reg n, Reg t, Imm12 imm12) {
-    if ((!P || W) && (n == Reg::PC || n == t))
+    if ((!P || W) && (n == Reg::PC || n == t)) {
         return UnpredictableInstruction();
-
-    // STR <Rt>, [<Rn>, #+/-<imm>]{!}
-    // STR <Rt>, [<Rn>], #+/-<imm>
-    if (ConditionPassed(cond)) {
-        const auto offset = ir.Imm32(imm12);
-        const auto address = GetAddress(ir, P, U, W, n, offset);
-        ir.WriteMemory32(address, ir.GetRegister(t));
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto offset = ir.Imm32(imm12);
+    const auto address = GetAddress(ir, P, U, W, n, offset);
+    ir.WriteMemory32(address, ir.GetRegister(t));
     return true;
 }
 
+// STR <Rt>, [<Rn>, #+/-<Rm>]{!}
+// STR <Rt>, [<Rn>], #+/-<Rm>
 bool ArmTranslatorVisitor::arm_STR_reg(Cond cond, bool P, bool U, bool W, Reg n, Reg t, Imm5 imm5, ShiftType shift, Reg m) {
-    if (m == Reg::PC)
+    if (m == Reg::PC) {
         return UnpredictableInstruction();
-
-    if ((!P || W) && (n == Reg::PC || n == t))
-        return UnpredictableInstruction();
-
-    // STR <Rt>, [<Rn>, #+/-<Rm>]{!}
-    // STR <Rt>, [<Rn>], #+/-<Rm>
-    if (ConditionPassed(cond)) {
-        const auto offset = EmitImmShift(ir.GetRegister(m), shift, imm5, ir.GetCFlag()).result;
-        const auto address = GetAddress(ir, P, U, W, n, offset);
-        ir.WriteMemory32(address, ir.GetRegister(t));
     }
+
+    if ((!P || W) && (n == Reg::PC || n == t)) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto offset = EmitImmShift(ir.GetRegister(m), shift, imm5, ir.GetCFlag()).result;
+    const auto address = GetAddress(ir, P, U, W, n, offset);
+    ir.WriteMemory32(address, ir.GetRegister(t));
     return true;
 }
 
+// STRB <Rt>, [<Rn>, #+/-<imm>]{!}
+// STRB <Rt>, [<Rn>], #+/-<imm>
 bool ArmTranslatorVisitor::arm_STRB_imm(Cond cond, bool P, bool U, bool W, Reg n, Reg t, Imm12 imm12) {
-    if (t == Reg::PC)
+    if (t == Reg::PC) {
         return UnpredictableInstruction();
-
-    if ((!P || W) && (n == Reg::PC || n == t))
-        return UnpredictableInstruction();
-
-    // STRB <Rt>, [<Rn>, #+/-<imm>]{!}
-    // STRB <Rt>, [<Rn>], #+/-<imm>
-    if (ConditionPassed(cond)) {
-        const auto offset = ir.Imm32(imm12);
-        const auto address = GetAddress(ir, P, U, W, n, offset);
-        ir.WriteMemory8(address, ir.LeastSignificantByte(ir.GetRegister(t)));
     }
+
+    if ((!P || W) && (n == Reg::PC || n == t)) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto offset = ir.Imm32(imm12);
+    const auto address = GetAddress(ir, P, U, W, n, offset);
+    ir.WriteMemory8(address, ir.LeastSignificantByte(ir.GetRegister(t)));
     return true;
 }
 
+// STRB <Rt>, [<Rn>, #+/-<Rm>]{!}
+// STRB <Rt>, [<Rn>], #+/-<Rm>
 bool ArmTranslatorVisitor::arm_STRB_reg(Cond cond, bool P, bool U, bool W, Reg n, Reg t, Imm5 imm5, ShiftType shift, Reg m) {
-    if (t == Reg::PC || m == Reg::PC)
+    if (t == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    if ((!P || W) && (n == Reg::PC || n == t))
-        return UnpredictableInstruction();
-
-    // STRB <Rt>, [<Rn>, #+/-<Rm>]{!}
-    // STRB <Rt>, [<Rn>], #+/-<Rm>
-    if (ConditionPassed(cond)) {
-        const auto offset = EmitImmShift(ir.GetRegister(m), shift, imm5, ir.GetCFlag()).result;
-        const auto address = GetAddress(ir, P, U, W, n, offset);
-        ir.WriteMemory8(address, ir.LeastSignificantByte(ir.GetRegister(t)));
     }
+
+    if ((!P || W) && (n == Reg::PC || n == t)) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto offset = EmitImmShift(ir.GetRegister(m), shift, imm5, ir.GetCFlag()).result;
+    const auto address = GetAddress(ir, P, U, W, n, offset);
+    ir.WriteMemory8(address, ir.LeastSignificantByte(ir.GetRegister(t)));
     return true;
 }
 
+// STRD <Rt>, [<Rn>, #+/-<imm>]{!}
+// STRD <Rt>, [<Rn>], #+/-<imm>
 bool ArmTranslatorVisitor::arm_STRD_imm(Cond cond, bool P, bool U, bool W, Reg n, Reg t, Imm4 imm8a, Imm4 imm8b) {
-    if (size_t(t) % 2 != 0)
+    if (size_t(t) % 2 != 0) {
         return UnpredictableInstruction();
-    if (!P && W)
+    }
+
+    if (!P && W) {
         return UnpredictableInstruction();
+    }
+
+    const Reg t2 = t + 1;
+    if ((!P || W) && (n == Reg::PC || n == t || n == t2)) {
+        return UnpredictableInstruction();
+    }
+
+    if (t2 == Reg::PC) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
 
     const u32 imm32 = imm8a << 4 | imm8b;
-    const Reg t2 = t + 1;
+    const auto offset = ir.Imm32(imm32);
+    const auto address_a = GetAddress(ir, P, U, W, n, offset);
+    const auto address_b = ir.Add(address_a, ir.Imm32(4));
+    const auto value_a = ir.GetRegister(t);
+    const auto value_b = ir.GetRegister(t2);
 
-    if ((!P || W) && (n == Reg::PC || n == t || n == t2))
-        return UnpredictableInstruction();
-    if (t2 == Reg::PC)
-        return UnpredictableInstruction();
-
-    // STRD <Rt>, [<Rn>, #+/-<imm>]{!}
-    // STRD <Rt>, [<Rn>], #+/-<imm>
-    if (ConditionPassed(cond)) {
-        const auto offset = ir.Imm32(imm32);
-        const auto address_a = GetAddress(ir, P, U, W, n, offset);
-        const auto address_b = ir.Add(address_a, ir.Imm32(4));
-        const auto value_a = ir.GetRegister(t);
-        const auto value_b = ir.GetRegister(t2);
-        ir.WriteMemory32(address_a, value_a);
-        ir.WriteMemory32(address_b, value_b);
-    }
+    ir.WriteMemory32(address_a, value_a);
+    ir.WriteMemory32(address_b, value_b);
     return true;
 }
 
+// STRD <Rt>, [<Rn>, #+/-<Rm>]{!}
+// STRD <Rt>, [<Rn>], #+/-<Rm>
 bool ArmTranslatorVisitor::arm_STRD_reg(Cond cond, bool P, bool U, bool W, Reg n, Reg t, Reg m) {
-    if (size_t(t) % 2 != 0)
+    if (size_t(t) % 2 != 0) {
         return UnpredictableInstruction();
-    if (!P && W)
+    }
+
+    if (!P && W) {
         return UnpredictableInstruction();
+    }
 
     const Reg t2 = t + 1;
-
-    if (t2 == Reg::PC || m == Reg::PC)
+    if (t2 == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if ((!P || W) && (n == Reg::PC || n == t || n == t2))
-        return UnpredictableInstruction();
-
-    // STRD <Rt>, [<Rn>, #+/-<Rm>]{!}
-    // STRD <Rt>, [<Rn>], #+/-<Rm>
-    if (ConditionPassed(cond)) {
-        const auto offset = ir.GetRegister(m);
-        const auto address_a = GetAddress(ir, P, U, W, n, offset);
-        const auto address_b = ir.Add(address_a, ir.Imm32(4));
-        const auto value_a = ir.GetRegister(t);
-        const auto value_b = ir.GetRegister(t2);
-        ir.WriteMemory32(address_a, value_a);
-        ir.WriteMemory32(address_b, value_b);
     }
+
+    if ((!P || W) && (n == Reg::PC || n == t || n == t2)) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto offset = ir.GetRegister(m);
+    const auto address_a = GetAddress(ir, P, U, W, n, offset);
+    const auto address_b = ir.Add(address_a, ir.Imm32(4));
+    const auto value_a = ir.GetRegister(t);
+    const auto value_b = ir.GetRegister(t2);
+
+    ir.WriteMemory32(address_a, value_a);
+    ir.WriteMemory32(address_b, value_b);
     return true;
 }
 
+// STRH <Rt>, [<Rn>, #+/-<imm>]{!}
+// STRH <Rt>, [<Rn>], #+/-<imm>
 bool ArmTranslatorVisitor::arm_STRH_imm(Cond cond, bool P, bool U, bool W, Reg n, Reg t, Imm4 imm8a, Imm4 imm8b) {
-    if (t == Reg::PC)
+    if (t == Reg::PC) {
         return UnpredictableInstruction();
-    if ((!P || W) && (n == Reg::PC || n == t))
+    }
+
+    if ((!P || W) && (n == Reg::PC || n == t)) {
         return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
 
     const u32 imm32 = imm8a << 4 | imm8b;
+    const auto offset = ir.Imm32(imm32);
+    const auto address = GetAddress(ir, P, U, W, n, offset);
 
-    // STRH <Rt>, [<Rn>, #+/-<imm>]{!}
-    // STRH <Rt>, [<Rn>], #+/-<imm>
-    if (ConditionPassed(cond)) {
-        const auto offset = ir.Imm32(imm32);
-        const auto address = GetAddress(ir, P, U, W, n, offset);
-        ir.WriteMemory16(address, ir.LeastSignificantHalf(ir.GetRegister(t)));
-    }
+    ir.WriteMemory16(address, ir.LeastSignificantHalf(ir.GetRegister(t)));
     return true;
 }
 
+// STRH <Rt>, [<Rn>, #+/-<Rm>]{!}
+// STRH <Rt>, [<Rn>], #+/-<Rm>
 bool ArmTranslatorVisitor::arm_STRH_reg(Cond cond, bool P, bool U, bool W, Reg n, Reg t, Reg m) {
-    if (t == Reg::PC || m == Reg::PC)
+    if (t == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if ((!P || W) && (n == Reg::PC || n == t))
-        return UnpredictableInstruction();
-
-    // STRH <Rt>, [<Rn>, #+/-<Rm>]{!}
-    // STRH <Rt>, [<Rn>], #+/-<Rm>
-    if (ConditionPassed(cond)) {
-        const auto offset = ir.GetRegister(m);
-        const auto address = GetAddress(ir, P, U, W, n, offset);
-        ir.WriteMemory16(address, ir.LeastSignificantHalf(ir.GetRegister(t)));
     }
+
+    if ((!P || W) && (n == Reg::PC || n == t)) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto offset = ir.GetRegister(m);
+    const auto address = GetAddress(ir, P, U, W, n, offset);
+
+    ir.WriteMemory16(address, ir.LeastSignificantHalf(ir.GetRegister(t)));
     return true;
 }
 
@@ -629,52 +763,64 @@ static bool LDMHelper(A32::IREmitter& ir, bool W, Reg n, RegList list, IR::U32 s
     return true;
 }
 
+// LDM <Rn>{!}, <reg_list>
 bool ArmTranslatorVisitor::arm_LDM(Cond cond, bool W, Reg n, RegList list) {
-    if (n == Reg::PC || Common::BitCount(list) < 1)
+    if (n == Reg::PC || Common::BitCount(list) < 1) {
         return UnpredictableInstruction();
-    // LDM <Rn>{!}, <reg_list>
-    if (ConditionPassed(cond)) {
-        auto start_address = ir.GetRegister(n);
-        auto writeback_address = ir.Add(start_address, ir.Imm32(u32(Common::BitCount(list) * 4)));
-        return LDMHelper(ir, W, n, list, start_address, writeback_address);
     }
-    return true;
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto start_address = ir.GetRegister(n);
+    const auto writeback_address = ir.Add(start_address, ir.Imm32(u32(Common::BitCount(list) * 4)));
+    return LDMHelper(ir, W, n, list, start_address, writeback_address);
 }
 
+// LDMDA <Rn>{!}, <reg_list>
 bool ArmTranslatorVisitor::arm_LDMDA(Cond cond, bool W, Reg n, RegList list) {
-    if (n == Reg::PC || Common::BitCount(list) < 1)
+    if (n == Reg::PC || Common::BitCount(list) < 1) {
         return UnpredictableInstruction();
-    // LDMDA <Rn>{!}, <reg_list>
-    if (ConditionPassed(cond)) {
-        auto start_address = ir.Sub(ir.GetRegister(n), ir.Imm32(u32(4 * Common::BitCount(list) - 4)));
-        auto writeback_address = ir.Sub(start_address, ir.Imm32(4));
-        return LDMHelper(ir, W, n, list, start_address, writeback_address);
     }
-    return true;
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto start_address = ir.Sub(ir.GetRegister(n), ir.Imm32(u32(4 * Common::BitCount(list) - 4)));
+    const auto writeback_address = ir.Sub(start_address, ir.Imm32(4));
+    return LDMHelper(ir, W, n, list, start_address, writeback_address);
 }
 
+// LDMDB <Rn>{!}, <reg_list>
 bool ArmTranslatorVisitor::arm_LDMDB(Cond cond, bool W, Reg n, RegList list) {
-    if (n == Reg::PC || Common::BitCount(list) < 1)
+    if (n == Reg::PC || Common::BitCount(list) < 1) {
         return UnpredictableInstruction();
-    // LDMDB <Rn>{!}, <reg_list>
-    if (ConditionPassed(cond)) {
-        auto start_address = ir.Sub(ir.GetRegister(n), ir.Imm32(u32(4 * Common::BitCount(list))));
-        auto writeback_address = start_address;
-        return LDMHelper(ir, W, n, list, start_address, writeback_address);
     }
-    return true;
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto start_address = ir.Sub(ir.GetRegister(n), ir.Imm32(u32(4 * Common::BitCount(list))));
+    const auto writeback_address = start_address;
+    return LDMHelper(ir, W, n, list, start_address, writeback_address);
 }
 
+// LDMIB <Rn>{!}, <reg_list>
 bool ArmTranslatorVisitor::arm_LDMIB(Cond cond, bool W, Reg n, RegList list) {
-    if (n == Reg::PC || Common::BitCount(list) < 1)
+    if (n == Reg::PC || Common::BitCount(list) < 1) {
         return UnpredictableInstruction();
-    // LDMIB <Rn>{!}, <reg_list>
-    if (ConditionPassed(cond)) {
-        auto start_address = ir.Add(ir.GetRegister(n), ir.Imm32(4));
-        auto writeback_address = ir.Add(ir.GetRegister(n), ir.Imm32(u32(4 * Common::BitCount(list))));
-        return LDMHelper(ir, W, n, list, start_address, writeback_address);
     }
-    return true;
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto start_address = ir.Add(ir.GetRegister(n), ir.Imm32(4));
+    const auto writeback_address = ir.Add(ir.GetRegister(n), ir.Imm32(u32(4 * Common::BitCount(list))));
+    return LDMHelper(ir, W, n, list, start_address, writeback_address);
 }
 
 bool ArmTranslatorVisitor::arm_LDM_usr() {
@@ -702,52 +848,64 @@ static bool STMHelper(A32::IREmitter& ir, bool W, Reg n, RegList list, IR::U32 s
     return true;
 }
 
+// STM <Rn>{!}, <reg_list>
 bool ArmTranslatorVisitor::arm_STM(Cond cond, bool W, Reg n, RegList list) {
-    if (n == Reg::PC || Common::BitCount(list) < 1)
+    if (n == Reg::PC || Common::BitCount(list) < 1) {
         return UnpredictableInstruction();
-    // STM <Rn>{!}, <reg_list>
-    if (ConditionPassed(cond)) {
-        auto start_address = ir.GetRegister(n);
-        auto writeback_address = ir.Add(start_address, ir.Imm32(u32(Common::BitCount(list) * 4)));
-        return STMHelper(ir, W, n, list, start_address, writeback_address);
     }
-    return true;
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto start_address = ir.GetRegister(n);
+    const auto writeback_address = ir.Add(start_address, ir.Imm32(u32(Common::BitCount(list) * 4)));
+    return STMHelper(ir, W, n, list, start_address, writeback_address);
 }
 
+// STMDA <Rn>{!}, <reg_list>
 bool ArmTranslatorVisitor::arm_STMDA(Cond cond, bool W, Reg n, RegList list) {
-    if (n == Reg::PC || Common::BitCount(list) < 1)
+    if (n == Reg::PC || Common::BitCount(list) < 1) {
         return UnpredictableInstruction();
-    // STMDA <Rn>{!}, <reg_list>
-    if (ConditionPassed(cond)) {
-        auto start_address = ir.Sub(ir.GetRegister(n), ir.Imm32(u32(4 * Common::BitCount(list) - 4)));
-        auto writeback_address = ir.Sub(start_address, ir.Imm32(4));
-        return STMHelper(ir, W, n, list, start_address, writeback_address);
     }
-    return true;
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto start_address = ir.Sub(ir.GetRegister(n), ir.Imm32(u32(4 * Common::BitCount(list) - 4)));
+    const auto writeback_address = ir.Sub(start_address, ir.Imm32(4));
+    return STMHelper(ir, W, n, list, start_address, writeback_address);
 }
 
+// STMDB <Rn>{!}, <reg_list>
 bool ArmTranslatorVisitor::arm_STMDB(Cond cond, bool W, Reg n, RegList list) {
-    if (n == Reg::PC || Common::BitCount(list) < 1)
+    if (n == Reg::PC || Common::BitCount(list) < 1) {
         return UnpredictableInstruction();
-    // STMDB <Rn>{!}, <reg_list>
-    if (ConditionPassed(cond)) {
-        auto start_address = ir.Sub(ir.GetRegister(n), ir.Imm32(u32(4 * Common::BitCount(list))));
-        auto writeback_address = start_address;
-        return STMHelper(ir, W, n, list, start_address, writeback_address);
     }
-    return true;
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto start_address = ir.Sub(ir.GetRegister(n), ir.Imm32(u32(4 * Common::BitCount(list))));
+    const auto writeback_address = start_address;
+    return STMHelper(ir, W, n, list, start_address, writeback_address);
 }
 
+// STMIB <Rn>{!}, <reg_list>
 bool ArmTranslatorVisitor::arm_STMIB(Cond cond, bool W, Reg n, RegList list) {
-    if (n == Reg::PC || Common::BitCount(list) < 1)
+    if (n == Reg::PC || Common::BitCount(list) < 1) {
         return UnpredictableInstruction();
-    // STMIB <Rn>{!}, <reg_list>
-    if (ConditionPassed(cond)) {
-        auto start_address = ir.Add(ir.GetRegister(n), ir.Imm32(4));
-        auto writeback_address = ir.Add(ir.GetRegister(n), ir.Imm32(u32(4 * Common::BitCount(list))));
-        return STMHelper(ir, W, n, list, start_address, writeback_address);
     }
-    return true;
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto start_address = ir.Add(ir.GetRegister(n), ir.Imm32(4));
+    const auto writeback_address = ir.Add(ir.GetRegister(n), ir.Imm32(u32(4 * Common::BitCount(list))));
+    return STMHelper(ir, W, n, list, start_address, writeback_address);
 }
 
 bool ArmTranslatorVisitor::arm_STM_usr() {

--- a/src/frontend/A32/translate/translate_arm/misc.cpp
+++ b/src/frontend/A32/translate/translate_arm/misc.cpp
@@ -8,26 +8,35 @@
 
 namespace Dynarmic::A32 {
 
+// CLZ<c> <Rd>, <Rm>
 bool ArmTranslatorVisitor::arm_CLZ(Cond cond, Reg d, Reg m) {
-    if (d == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        ir.SetRegister(d, ir.CountLeadingZeros(ir.GetRegister(m)));
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    ir.SetRegister(d, ir.CountLeadingZeros(ir.GetRegister(m)));
     return true;
 }
 
+// SEL<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_SEL(Cond cond, Reg n, Reg d, Reg m) {
-    if (n == Reg::PC || d == Reg::PC || m == Reg::PC)
+    if (n == Reg::PC || d == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    if (ConditionPassed(cond)) {
-        auto to = ir.GetRegister(m);
-        auto from = ir.GetRegister(n);
-        auto result = ir.PackedSelect(ir.GetGEFlags(), to, from);
-        ir.SetRegister(d, result);
     }
 
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto to = ir.GetRegister(m);
+    const auto from = ir.GetRegister(n);
+    const auto result = ir.PackedSelect(ir.GetGEFlags(), to, from);
+
+    ir.SetRegister(d, result);
     return true;
 }
 

--- a/src/frontend/A32/translate/translate_arm/multiply.cpp
+++ b/src/frontend/A32/translate/translate_arm/multiply.cpp
@@ -8,423 +8,585 @@
 
 namespace Dynarmic::A32 {
 
-// Multiply (Normal) instructions
+// MLA{S}<c> <Rd>, <Rn>, <Rm>, <Ra>
 bool ArmTranslatorVisitor::arm_MLA(Cond cond, bool S, Reg d, Reg a, Reg m, Reg n) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC || a == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC || a == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.Add(ir.Mul(ir.GetRegister(n), ir.GetRegister(m)), ir.GetRegister(a));
-        ir.SetRegister(d, result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result));
-            ir.SetZFlag(ir.IsZero(result));
-        }
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.Add(ir.Mul(ir.GetRegister(n), ir.GetRegister(m)), ir.GetRegister(a));
+    ir.SetRegister(d, result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result));
+        ir.SetZFlag(ir.IsZero(result));
+    }
+
     return true;
 }
 
+// MUL{S}<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_MUL(Cond cond, bool S, Reg d, Reg m, Reg n) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.Mul(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(result));
-            ir.SetZFlag(ir.IsZero(result));
-        }
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.Mul(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(result));
+        ir.SetZFlag(ir.IsZero(result));
+    }
+
     return true;
 }
 
 
-// Multiply (Long) instructions
+// SMLAL{S}<c> <RdLo>, <RdHi>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_SMLAL(Cond cond, bool S, Reg dHi, Reg dLo, Reg m, Reg n) {
-    if (dLo == Reg::PC || dHi == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (dLo == Reg::PC || dHi == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (dLo == dHi)
-        return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto n64 = ir.SignExtendWordToLong(ir.GetRegister(n));
-        auto m64 = ir.SignExtendWordToLong(ir.GetRegister(m));
-        auto product = ir.Mul(n64, m64);
-        auto addend = ir.Pack2x32To1x64(ir.GetRegister(dLo), ir.GetRegister(dHi));
-        auto result = ir.Add(product, addend);
-        auto lo = ir.LeastSignificantWord(result);
-        auto hi = ir.MostSignificantWord(result).result;
-        ir.SetRegister(dLo, lo);
-        ir.SetRegister(dHi, hi);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(hi));
-            ir.SetZFlag(ir.IsZero(result));
-        }
     }
+
+    if (dLo == dHi) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto n64 = ir.SignExtendWordToLong(ir.GetRegister(n));
+    const auto m64 = ir.SignExtendWordToLong(ir.GetRegister(m));
+    const auto product = ir.Mul(n64, m64);
+    const auto addend = ir.Pack2x32To1x64(ir.GetRegister(dLo), ir.GetRegister(dHi));
+    const auto result = ir.Add(product, addend);
+    const auto lo = ir.LeastSignificantWord(result);
+    const auto hi = ir.MostSignificantWord(result).result;
+
+    ir.SetRegister(dLo, lo);
+    ir.SetRegister(dHi, hi);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(hi));
+        ir.SetZFlag(ir.IsZero(result));
+    }
+
     return true;
 }
 
+// SMULL{S}<c> <RdLo>, <RdHi>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_SMULL(Cond cond, bool S, Reg dHi, Reg dLo, Reg m, Reg n) {
-    if (dLo == Reg::PC || dHi == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (dLo == Reg::PC || dHi == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (dLo == dHi)
-        return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto n64 = ir.SignExtendWordToLong(ir.GetRegister(n));
-        auto m64 = ir.SignExtendWordToLong(ir.GetRegister(m));
-        auto result = ir.Mul(n64, m64);
-        auto lo = ir.LeastSignificantWord(result);
-        auto hi = ir.MostSignificantWord(result).result;
-        ir.SetRegister(dLo, lo);
-        ir.SetRegister(dHi, hi);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(hi));
-            ir.SetZFlag(ir.IsZero(result));
-        }
     }
+
+    if (dLo == dHi) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto n64 = ir.SignExtendWordToLong(ir.GetRegister(n));
+    const auto m64 = ir.SignExtendWordToLong(ir.GetRegister(m));
+    const auto result = ir.Mul(n64, m64);
+    const auto lo = ir.LeastSignificantWord(result);
+    const auto hi = ir.MostSignificantWord(result).result;
+
+    ir.SetRegister(dLo, lo);
+    ir.SetRegister(dHi, hi);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(hi));
+        ir.SetZFlag(ir.IsZero(result));
+    }
+
     return true;
 }
 
+// UMAAL<c> <RdLo>, <RdHi>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_UMAAL(Cond cond, Reg dHi, Reg dLo, Reg m, Reg n) {
-    if (dLo == Reg::PC || dHi == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (dLo == Reg::PC || dHi == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (dLo == dHi)
-        return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto lo64 = ir.ZeroExtendWordToLong(ir.GetRegister(dLo));
-        auto hi64 = ir.ZeroExtendWordToLong(ir.GetRegister(dHi));
-        auto n64 = ir.ZeroExtendWordToLong(ir.GetRegister(n));
-        auto m64 = ir.ZeroExtendWordToLong(ir.GetRegister(m));
-        auto result = ir.Add(ir.Add(ir.Mul(n64, m64), hi64), lo64);
-        ir.SetRegister(dLo, ir.LeastSignificantWord(result));
-        ir.SetRegister(dHi, ir.MostSignificantWord(result).result);
     }
+
+    if (dLo == dHi) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto lo64 = ir.ZeroExtendWordToLong(ir.GetRegister(dLo));
+    const auto hi64 = ir.ZeroExtendWordToLong(ir.GetRegister(dHi));
+    const auto n64 = ir.ZeroExtendWordToLong(ir.GetRegister(n));
+    const auto m64 = ir.ZeroExtendWordToLong(ir.GetRegister(m));
+    const auto result = ir.Add(ir.Add(ir.Mul(n64, m64), hi64), lo64);
+
+    ir.SetRegister(dLo, ir.LeastSignificantWord(result));
+    ir.SetRegister(dHi, ir.MostSignificantWord(result).result);
     return true;
 }
 
+// UMLAL{S}<c> <RdLo>, <RdHi>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_UMLAL(Cond cond, bool S, Reg dHi, Reg dLo, Reg m, Reg n) {
-    if (dLo == Reg::PC || dHi == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (dLo == Reg::PC || dHi == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (dLo == dHi)
-        return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto addend = ir.Pack2x32To1x64(ir.GetRegister(dLo), ir.GetRegister(dHi));
-        auto n64 = ir.ZeroExtendWordToLong(ir.GetRegister(n));
-        auto m64 = ir.ZeroExtendWordToLong(ir.GetRegister(m));
-        auto result = ir.Add(ir.Mul(n64, m64), addend);
-        auto lo = ir.LeastSignificantWord(result);
-        auto hi = ir.MostSignificantWord(result).result;
-        ir.SetRegister(dLo, lo);
-        ir.SetRegister(dHi, hi);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(hi));
-            ir.SetZFlag(ir.IsZero(result));
-        }
     }
+
+    if (dLo == dHi) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto addend = ir.Pack2x32To1x64(ir.GetRegister(dLo), ir.GetRegister(dHi));
+    const auto n64 = ir.ZeroExtendWordToLong(ir.GetRegister(n));
+    const auto m64 = ir.ZeroExtendWordToLong(ir.GetRegister(m));
+    const auto result = ir.Add(ir.Mul(n64, m64), addend);
+    const auto lo = ir.LeastSignificantWord(result);
+    const auto hi = ir.MostSignificantWord(result).result;
+
+    ir.SetRegister(dLo, lo);
+    ir.SetRegister(dHi, hi);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(hi));
+        ir.SetZFlag(ir.IsZero(result));
+    }
+
     return true;
 }
 
+// UMULL{S}<c> <RdLo>, <RdHi>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_UMULL(Cond cond, bool S, Reg dHi, Reg dLo, Reg m, Reg n) {
-    if (dLo == Reg::PC || dHi == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (dLo == Reg::PC || dHi == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (dLo == dHi)
-        return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto n64 = ir.ZeroExtendWordToLong(ir.GetRegister(n));
-        auto m64 = ir.ZeroExtendWordToLong(ir.GetRegister(m));
-        auto result = ir.Mul(n64, m64);
-        auto lo = ir.LeastSignificantWord(result);
-        auto hi = ir.MostSignificantWord(result).result;
-        ir.SetRegister(dLo, lo);
-        ir.SetRegister(dHi, hi);
-        if (S) {
-            ir.SetNFlag(ir.MostSignificantBit(hi));
-            ir.SetZFlag(ir.IsZero(result));
-        }
     }
+
+    if (dLo == dHi) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto n64 = ir.ZeroExtendWordToLong(ir.GetRegister(n));
+    const auto m64 = ir.ZeroExtendWordToLong(ir.GetRegister(m));
+    const auto result = ir.Mul(n64, m64);
+    const auto lo = ir.LeastSignificantWord(result);
+    const auto hi = ir.MostSignificantWord(result).result;
+
+    ir.SetRegister(dLo, lo);
+    ir.SetRegister(dHi, hi);
+    if (S) {
+        ir.SetNFlag(ir.MostSignificantBit(hi));
+        ir.SetZFlag(ir.IsZero(result));
+    }
+
     return true;
 }
 
-
-// Multiply (Halfword) instructions
+// SMLAL<x><y><c> <RdLo>, <RdHi>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_SMLALxy(Cond cond, Reg dHi, Reg dLo, Reg m, bool M, bool N, Reg n) {
-    if (dLo == Reg::PC || dHi == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (dLo == Reg::PC || dHi == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (dLo == dHi)
-        return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        const IR::U32 n32 = ir.GetRegister(n);
-        const IR::U32 m32 = ir.GetRegister(m);
-        const IR::U32 n16 = N ? ir.ArithmeticShiftRight(n32, ir.Imm8(16), ir.Imm1(0)).result
-                              : ir.SignExtendHalfToWord(ir.LeastSignificantHalf(n32));
-        const IR::U32 m16 = M ? ir.ArithmeticShiftRight(m32, ir.Imm8(16), ir.Imm1(0)).result
-                              : ir.SignExtendHalfToWord(ir.LeastSignificantHalf(m32));
-        const IR::U64 product = ir.SignExtendWordToLong(ir.Mul(n16, m16));
-        auto addend = ir.Pack2x32To1x64(ir.GetRegister(dLo), ir.GetRegister(dHi));
-        auto result = ir.Add(product, addend);
-        ir.SetRegister(dLo, ir.LeastSignificantWord(result));
-        ir.SetRegister(dHi, ir.MostSignificantWord(result).result);
     }
+
+    if (dLo == dHi) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const IR::U32 n32 = ir.GetRegister(n);
+    const IR::U32 m32 = ir.GetRegister(m);
+    const IR::U32 n16 = N ? ir.ArithmeticShiftRight(n32, ir.Imm8(16), ir.Imm1(0)).result
+                          : ir.SignExtendHalfToWord(ir.LeastSignificantHalf(n32));
+    const IR::U32 m16 = M ? ir.ArithmeticShiftRight(m32, ir.Imm8(16), ir.Imm1(0)).result
+                          : ir.SignExtendHalfToWord(ir.LeastSignificantHalf(m32));
+    const IR::U64 product = ir.SignExtendWordToLong(ir.Mul(n16, m16));
+    const auto addend = ir.Pack2x32To1x64(ir.GetRegister(dLo), ir.GetRegister(dHi));
+    const auto result = ir.Add(product, addend);
+
+    ir.SetRegister(dLo, ir.LeastSignificantWord(result));
+    ir.SetRegister(dHi, ir.MostSignificantWord(result).result);
     return true;
 }
 
+// SMLA<x><y><c> <Rd>, <Rn>, <Rm>, <Ra>
 bool ArmTranslatorVisitor::arm_SMLAxy(Cond cond, Reg d, Reg a, Reg m, bool M, bool N, Reg n) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC || a == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC || a == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        const IR::U32 n32 = ir.GetRegister(n);
-        const IR::U32 m32 = ir.GetRegister(m);
-        const IR::U32 n16 = N ? ir.ArithmeticShiftRight(n32, ir.Imm8(16), ir.Imm1(0)).result
-                              : ir.SignExtendHalfToWord(ir.LeastSignificantHalf(n32));
-        const IR::U32 m16 = M ? ir.ArithmeticShiftRight(m32, ir.Imm8(16), ir.Imm1(0)).result
-                              : ir.SignExtendHalfToWord(ir.LeastSignificantHalf(m32));
-        const IR::U32 product = ir.Mul(n16, m16);
-        auto result_overflow = ir.AddWithCarry(product, ir.GetRegister(a), ir.Imm1(0));
-        ir.SetRegister(d, result_overflow.result);
-        ir.OrQFlag(result_overflow.overflow);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const IR::U32 n32 = ir.GetRegister(n);
+    const IR::U32 m32 = ir.GetRegister(m);
+    const IR::U32 n16 = N ? ir.ArithmeticShiftRight(n32, ir.Imm8(16), ir.Imm1(0)).result
+                          : ir.SignExtendHalfToWord(ir.LeastSignificantHalf(n32));
+    const IR::U32 m16 = M ? ir.ArithmeticShiftRight(m32, ir.Imm8(16), ir.Imm1(0)).result
+                          : ir.SignExtendHalfToWord(ir.LeastSignificantHalf(m32));
+    const IR::U32 product = ir.Mul(n16, m16);
+    const auto result_overflow = ir.AddWithCarry(product, ir.GetRegister(a), ir.Imm1(0));
+
+    ir.SetRegister(d, result_overflow.result);
+    ir.OrQFlag(result_overflow.overflow);
     return true;
 }
 
+// SMUL<x><y><c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_SMULxy(Cond cond, Reg d, Reg m, bool M, bool N, Reg n) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        const IR::U32 n32 = ir.GetRegister(n);
-        const IR::U32 m32 = ir.GetRegister(m);
-        const IR::U32 n16 = N ? ir.ArithmeticShiftRight(n32, ir.Imm8(16), ir.Imm1(0)).result
-                              : ir.SignExtendHalfToWord(ir.LeastSignificantHalf(n32));
-        const IR::U32 m16 = M ? ir.ArithmeticShiftRight(m32, ir.Imm8(16), ir.Imm1(0)).result
-                              : ir.SignExtendHalfToWord(ir.LeastSignificantHalf(m32));
-        const IR::U32 result = ir.Mul(n16, m16);
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const IR::U32 n32 = ir.GetRegister(n);
+    const IR::U32 m32 = ir.GetRegister(m);
+    const IR::U32 n16 = N ? ir.ArithmeticShiftRight(n32, ir.Imm8(16), ir.Imm1(0)).result
+                          : ir.SignExtendHalfToWord(ir.LeastSignificantHalf(n32));
+    const IR::U32 m16 = M ? ir.ArithmeticShiftRight(m32, ir.Imm8(16), ir.Imm1(0)).result
+                          : ir.SignExtendHalfToWord(ir.LeastSignificantHalf(m32));
+    const IR::U32 result = ir.Mul(n16, m16);
+
+    ir.SetRegister(d, result);
     return true;
 }
 
-
-// Multiply (word by halfword) instructions
+// SMLAW<y><c> <Rd>, <Rn>, <Rm>, <Ra>
 bool ArmTranslatorVisitor::arm_SMLAWy(Cond cond, Reg d, Reg a, Reg m, bool M, Reg n) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC || a == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC || a == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        const IR::U64 n32 = ir.SignExtendWordToLong(ir.GetRegister(n));
-        IR::U32 m32 = ir.GetRegister(m);
-        if (M)
-            m32 = ir.LogicalShiftRight(m32, ir.Imm8(16), ir.Imm1(0)).result;
-        const IR::U64 m16 = ir.SignExtendWordToLong(ir.SignExtendHalfToWord(ir.LeastSignificantHalf(m32)));
-        auto product = ir.LeastSignificantWord(ir.LogicalShiftRight(ir.Mul(n32, m16), ir.Imm8(16)));
-        auto result_overflow = ir.AddWithCarry(product, ir.GetRegister(a), ir.Imm1(0));
-        ir.SetRegister(d, result_overflow.result);
-        ir.OrQFlag(result_overflow.overflow);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const IR::U64 n32 = ir.SignExtendWordToLong(ir.GetRegister(n));
+    IR::U32 m32 = ir.GetRegister(m);
+    if (M) {
+        m32 = ir.LogicalShiftRight(m32, ir.Imm8(16), ir.Imm1(0)).result;
+    }
+    const IR::U64 m16 = ir.SignExtendWordToLong(ir.SignExtendHalfToWord(ir.LeastSignificantHalf(m32)));
+    const auto product = ir.LeastSignificantWord(ir.LogicalShiftRight(ir.Mul(n32, m16), ir.Imm8(16)));
+    const auto result_overflow = ir.AddWithCarry(product, ir.GetRegister(a), ir.Imm1(0));
+
+    ir.SetRegister(d, result_overflow.result);
+    ir.OrQFlag(result_overflow.overflow);
     return true;
 }
 
+// SMULW<y><c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_SMULWy(Cond cond, Reg d, Reg m, bool M, Reg n) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        const IR::U64 n32 = ir.SignExtendWordToLong(ir.GetRegister(n));
-        IR::U32 m32 = ir.GetRegister(m);
-        if (M)
-            m32 = ir.LogicalShiftRight(m32, ir.Imm8(16), ir.Imm1(0)).result;
-        const IR::U64 m16 = ir.SignExtendWordToLong(ir.SignExtendHalfToWord(ir.LeastSignificantHalf(m32)));
-        auto result = ir.LogicalShiftRight(ir.Mul(n32, m16), ir.Imm8(16));
-        ir.SetRegister(d, ir.LeastSignificantWord(result));
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const IR::U64 n32 = ir.SignExtendWordToLong(ir.GetRegister(n));
+    IR::U32 m32 = ir.GetRegister(m);
+    if (M) {
+        m32 = ir.LogicalShiftRight(m32, ir.Imm8(16), ir.Imm1(0)).result;
+    }
+    const IR::U64 m16 = ir.SignExtendWordToLong(ir.SignExtendHalfToWord(ir.LeastSignificantHalf(m32)));
+    const auto result = ir.LogicalShiftRight(ir.Mul(n32, m16), ir.Imm8(16));
+
+    ir.SetRegister(d, ir.LeastSignificantWord(result));
     return true;
 }
 
-
-// Multiply (Most significant word) instructions
+// SMMLA{R}<c> <Rd>, <Rn>, <Rm>, <Ra>
 bool ArmTranslatorVisitor::arm_SMMLA(Cond cond, Reg d, Reg a, Reg m, bool R, Reg n) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC /* no check for a */)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC /* no check for a */) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto n64 = ir.SignExtendWordToLong(ir.GetRegister(n));
-        auto m64 = ir.SignExtendWordToLong(ir.GetRegister(m));
-        auto a64 = ir.Pack2x32To1x64(ir.Imm32(0), ir.GetRegister(a));
-        auto temp = ir.Add(a64, ir.Mul(n64, m64));
-        auto result_carry = ir.MostSignificantWord(temp);
-        auto result = result_carry.result;
-        if (R)
-            result = ir.AddWithCarry(result, ir.Imm32(0), result_carry.carry).result;
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto n64 = ir.SignExtendWordToLong(ir.GetRegister(n));
+    const auto m64 = ir.SignExtendWordToLong(ir.GetRegister(m));
+    const auto a64 = ir.Pack2x32To1x64(ir.Imm32(0), ir.GetRegister(a));
+    const auto temp = ir.Add(a64, ir.Mul(n64, m64));
+    const auto result_carry = ir.MostSignificantWord(temp);
+    auto result = result_carry.result;
+    if (R) {
+        result = ir.AddWithCarry(result, ir.Imm32(0), result_carry.carry).result;
+    }
+
+    ir.SetRegister(d, result);
     return true;
 }
 
+// SMMLS{R}<c> <Rd>, <Rn>, <Rm>, <Ra>
 bool ArmTranslatorVisitor::arm_SMMLS(Cond cond, Reg d, Reg a, Reg m, bool R, Reg n) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC || a == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC || a == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto n64 = ir.SignExtendWordToLong(ir.GetRegister(n));
-        auto m64 = ir.SignExtendWordToLong(ir.GetRegister(m));
-        auto a64 = ir.Pack2x32To1x64(ir.Imm32(0), ir.GetRegister(a));
-        auto temp = ir.Sub(a64, ir.Mul(n64, m64));
-        auto result_carry = ir.MostSignificantWord(temp);
-        auto result = result_carry.result;
-        if (R)
-            result = ir.AddWithCarry(result, ir.Imm32(0), result_carry.carry).result;
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto n64 = ir.SignExtendWordToLong(ir.GetRegister(n));
+    const auto m64 = ir.SignExtendWordToLong(ir.GetRegister(m));
+    const auto a64 = ir.Pack2x32To1x64(ir.Imm32(0), ir.GetRegister(a));
+    const auto temp = ir.Sub(a64, ir.Mul(n64, m64));
+    const auto result_carry = ir.MostSignificantWord(temp);
+    auto result = result_carry.result;
+    if (R) {
+        result = ir.AddWithCarry(result, ir.Imm32(0), result_carry.carry).result;
+    }
+
+    ir.SetRegister(d, result);
     return true;
 }
 
+// SMMUL{R}<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_SMMUL(Cond cond, Reg d, Reg m, bool R, Reg n) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto n64 = ir.SignExtendWordToLong(ir.GetRegister(n));
-        auto m64 = ir.SignExtendWordToLong(ir.GetRegister(m));
-        auto product = ir.Mul(n64, m64);
-        auto result_carry = ir.MostSignificantWord(product);
-        auto result = result_carry.result;
-        if (R)
-            result = ir.AddWithCarry(result, ir.Imm32(0), result_carry.carry).result;
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto n64 = ir.SignExtendWordToLong(ir.GetRegister(n));
+    const auto m64 = ir.SignExtendWordToLong(ir.GetRegister(m));
+    const auto product = ir.Mul(n64, m64);
+    const auto result_carry = ir.MostSignificantWord(product);
+    auto result = result_carry.result;
+    if (R) {
+        result = ir.AddWithCarry(result, ir.Imm32(0), result_carry.carry).result;
+    }
+
+    ir.SetRegister(d, result);
     return true;
 }
 
-
-// Multiply (Dual) instructions
+// SMLAD{X}<c> <Rd>, <Rn>, <Rm>, <Ra>
 bool ArmTranslatorVisitor::arm_SMLAD(Cond cond, Reg d, Reg a, Reg m, bool M, Reg n) {
-    if (a == Reg::PC)
+    if (a == Reg::PC) {
         return arm_SMUAD(cond, d, m, M, n);
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
-        return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        const IR::U32 n32 = ir.GetRegister(n);
-        const IR::U32 m32 = ir.GetRegister(m);
-        const IR::U32 n_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(n32));
-        IR::U32 m_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(m32));
-        const IR::U32 n_hi = ir.ArithmeticShiftRight(n32, ir.Imm8(16), ir.Imm1(0)).result;
-        IR::U32 m_hi = ir.ArithmeticShiftRight(m32, ir.Imm8(16), ir.Imm1(0)).result;
-        if (M)
-            std::swap(m_lo, m_hi);
-        const IR::U32 product_lo = ir.Mul(n_lo, m_lo);
-        const IR::U32 product_hi = ir.Mul(n_hi, m_hi);
-        const IR::U32 addend = ir.GetRegister(a);
-        auto result_overflow = ir.AddWithCarry(product_lo, product_hi, ir.Imm1(0));
-        ir.OrQFlag(result_overflow.overflow);
-        result_overflow = ir.AddWithCarry(result_overflow.result, addend, ir.Imm1(0));
-        ir.SetRegister(d, result_overflow.result);
-        ir.OrQFlag(result_overflow.overflow);
     }
+
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const IR::U32 n32 = ir.GetRegister(n);
+    const IR::U32 m32 = ir.GetRegister(m);
+    const IR::U32 n_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(n32));
+    const IR::U32 n_hi = ir.ArithmeticShiftRight(n32, ir.Imm8(16), ir.Imm1(0)).result;
+
+    IR::U32 m_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(m32));
+    IR::U32 m_hi = ir.ArithmeticShiftRight(m32, ir.Imm8(16), ir.Imm1(0)).result;
+    if (M) {
+        std::swap(m_lo, m_hi);
+    }
+
+    const IR::U32 product_lo = ir.Mul(n_lo, m_lo);
+    const IR::U32 product_hi = ir.Mul(n_hi, m_hi);
+    const IR::U32 addend = ir.GetRegister(a);
+
+    auto result_overflow = ir.AddWithCarry(product_lo, product_hi, ir.Imm1(0));
+    ir.OrQFlag(result_overflow.overflow);
+    result_overflow = ir.AddWithCarry(result_overflow.result, addend, ir.Imm1(0));
+    ir.SetRegister(d, result_overflow.result);
+    ir.OrQFlag(result_overflow.overflow);
     return true;
 }
 
+// SMLALD{X}<c> <RdLo>, <RdHi>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_SMLALD(Cond cond, Reg dHi, Reg dLo, Reg m, bool M, Reg n) {
-    if (dLo == Reg::PC || dHi == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (dLo == Reg::PC || dHi == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (dLo == dHi)
-        return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        const IR::U32 n32 = ir.GetRegister(n);
-        const IR::U32 m32 = ir.GetRegister(m);
-        const IR::U32 n_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(n32));
-        IR::U32 m_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(m32));
-        const IR::U32 n_hi = ir.ArithmeticShiftRight(n32, ir.Imm8(16), ir.Imm1(0)).result;
-        IR::U32 m_hi = ir.ArithmeticShiftRight(m32, ir.Imm8(16), ir.Imm1(0)).result;
-        if (M)
-            std::swap(m_lo, m_hi);
-        const IR::U64 product_lo = ir.SignExtendWordToLong(ir.Mul(n_lo, m_lo));
-        const IR::U64 product_hi = ir.SignExtendWordToLong(ir.Mul(n_hi, m_hi));
-        auto addend = ir.Pack2x32To1x64(ir.GetRegister(dLo), ir.GetRegister(dHi));
-        auto result = ir.Add(ir.Add(product_lo, product_hi), addend);
-        ir.SetRegister(dLo, ir.LeastSignificantWord(result));
-        ir.SetRegister(dHi, ir.MostSignificantWord(result).result);
     }
+
+    if (dLo == dHi) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const IR::U32 n32 = ir.GetRegister(n);
+    const IR::U32 m32 = ir.GetRegister(m);
+    const IR::U32 n_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(n32));
+    const IR::U32 n_hi = ir.ArithmeticShiftRight(n32, ir.Imm8(16), ir.Imm1(0)).result;
+
+    IR::U32 m_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(m32));
+    IR::U32 m_hi = ir.ArithmeticShiftRight(m32, ir.Imm8(16), ir.Imm1(0)).result;
+    if (M) {
+        std::swap(m_lo, m_hi);
+    }
+
+    const IR::U64 product_lo = ir.SignExtendWordToLong(ir.Mul(n_lo, m_lo));
+    const IR::U64 product_hi = ir.SignExtendWordToLong(ir.Mul(n_hi, m_hi));
+    const auto addend = ir.Pack2x32To1x64(ir.GetRegister(dLo), ir.GetRegister(dHi));
+    const auto result = ir.Add(ir.Add(product_lo, product_hi), addend);
+
+    ir.SetRegister(dLo, ir.LeastSignificantWord(result));
+    ir.SetRegister(dHi, ir.MostSignificantWord(result).result);
     return true;
 }
 
+// SMLSD{X}<c> <Rd>, <Rn>, <Rm>, <Ra>
 bool ArmTranslatorVisitor::arm_SMLSD(Cond cond, Reg d, Reg a, Reg m, bool M, Reg n) {
-    if (a == Reg::PC)
+    if (a == Reg::PC) {
         return arm_SMUSD(cond, d, m, M, n);
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
-        return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        const IR::U32 n32 = ir.GetRegister(n);
-        const IR::U32 m32 = ir.GetRegister(m);
-        const IR::U32 n_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(n32));
-        IR::U32 m_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(m32));
-        const IR::U32 n_hi = ir.ArithmeticShiftRight(n32, ir.Imm8(16), ir.Imm1(0)).result;
-        IR::U32 m_hi = ir.ArithmeticShiftRight(m32, ir.Imm8(16), ir.Imm1(0)).result;
-        if (M)
-            std::swap(m_lo, m_hi);
-        const IR::U32 product_lo = ir.Mul(n_lo, m_lo);
-        const IR::U32 product_hi = ir.Mul(n_hi, m_hi);
-        const IR::U32 addend = ir.GetRegister(a);
-        const IR::U32 product = ir.Sub(product_lo, product_hi);
-        auto result_overflow = ir.AddWithCarry(product, addend, ir.Imm1(0));
-        ir.SetRegister(d, result_overflow.result);
-        ir.OrQFlag(result_overflow.overflow);
     }
+
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const IR::U32 n32 = ir.GetRegister(n);
+    const IR::U32 m32 = ir.GetRegister(m);
+    const IR::U32 n_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(n32));
+    const IR::U32 n_hi = ir.ArithmeticShiftRight(n32, ir.Imm8(16), ir.Imm1(0)).result;
+
+    IR::U32 m_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(m32));
+    IR::U32 m_hi = ir.ArithmeticShiftRight(m32, ir.Imm8(16), ir.Imm1(0)).result;
+    if (M) {
+        std::swap(m_lo, m_hi);
+    }
+
+    const IR::U32 product_lo = ir.Mul(n_lo, m_lo);
+    const IR::U32 product_hi = ir.Mul(n_hi, m_hi);
+    const IR::U32 addend = ir.GetRegister(a);
+    const IR::U32 product = ir.Sub(product_lo, product_hi);
+    auto result_overflow = ir.AddWithCarry(product, addend, ir.Imm1(0));
+
+    ir.SetRegister(d, result_overflow.result);
+    ir.OrQFlag(result_overflow.overflow);
     return true;
 }
 
+// SMLSLD{X}<c> <RdLo>, <RdHi>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_SMLSLD(Cond cond, Reg dHi, Reg dLo, Reg m, bool M, Reg n) {
-    if (dLo == Reg::PC || dHi == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (dLo == Reg::PC || dHi == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (dLo == dHi)
-        return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        const IR::U32 n32 = ir.GetRegister(n);
-        const IR::U32 m32 = ir.GetRegister(m);
-        const IR::U32 n_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(n32));
-        IR::U32 m_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(m32));
-        const IR::U32 n_hi = ir.ArithmeticShiftRight(n32, ir.Imm8(16), ir.Imm1(0)).result;
-        IR::U32 m_hi = ir.ArithmeticShiftRight(m32, ir.Imm8(16), ir.Imm1(0)).result;
-        if (M)
-            std::swap(m_lo, m_hi);
-        const IR::U64 product_lo = ir.SignExtendWordToLong(ir.Mul(n_lo, m_lo));
-        const IR::U64 product_hi = ir.SignExtendWordToLong(ir.Mul(n_hi, m_hi));
-        auto addend = ir.Pack2x32To1x64(ir.GetRegister(dLo), ir.GetRegister(dHi));
-        auto result = ir.Add(ir.Sub(product_lo, product_hi), addend);
-        ir.SetRegister(dLo, ir.LeastSignificantWord(result));
-        ir.SetRegister(dHi, ir.MostSignificantWord(result).result);
     }
+
+    if (dLo == dHi) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const IR::U32 n32 = ir.GetRegister(n);
+    const IR::U32 m32 = ir.GetRegister(m);
+    const IR::U32 n_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(n32));
+    const IR::U32 n_hi = ir.ArithmeticShiftRight(n32, ir.Imm8(16), ir.Imm1(0)).result;
+
+    IR::U32 m_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(m32));
+    IR::U32 m_hi = ir.ArithmeticShiftRight(m32, ir.Imm8(16), ir.Imm1(0)).result;
+    if (M) {
+        std::swap(m_lo, m_hi);
+    }
+
+    const IR::U64 product_lo = ir.SignExtendWordToLong(ir.Mul(n_lo, m_lo));
+    const IR::U64 product_hi = ir.SignExtendWordToLong(ir.Mul(n_hi, m_hi));
+    const auto addend = ir.Pack2x32To1x64(ir.GetRegister(dLo), ir.GetRegister(dHi));
+    const auto result = ir.Add(ir.Sub(product_lo, product_hi), addend);
+
+    ir.SetRegister(dLo, ir.LeastSignificantWord(result));
+    ir.SetRegister(dHi, ir.MostSignificantWord(result).result);
     return true;
 }
 
+// SMUAD{X}<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_SMUAD(Cond cond, Reg d, Reg m, bool M, Reg n) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        const IR::U32 n32 = ir.GetRegister(n);
-        const IR::U32 m32 = ir.GetRegister(m);
-        const IR::U32 n_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(n32));
-        IR::U32 m_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(m32));
-        const IR::U32 n_hi = ir.ArithmeticShiftRight(n32, ir.Imm8(16), ir.Imm1(0)).result;
-        IR::U32 m_hi = ir.ArithmeticShiftRight(m32, ir.Imm8(16), ir.Imm1(0)).result;
-        if (M)
-            std::swap(m_lo, m_hi);
-        const IR::U32 product_lo = ir.Mul(n_lo, m_lo);
-        const IR::U32 product_hi = ir.Mul(n_hi, m_hi);
-        auto result_overflow = ir.AddWithCarry(product_lo, product_hi, ir.Imm1(0));
-        ir.SetRegister(d, result_overflow.result);
-        ir.OrQFlag(result_overflow.overflow);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const IR::U32 n32 = ir.GetRegister(n);
+    const IR::U32 m32 = ir.GetRegister(m);
+    const IR::U32 n_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(n32));
+    const IR::U32 n_hi = ir.ArithmeticShiftRight(n32, ir.Imm8(16), ir.Imm1(0)).result;
+
+    IR::U32 m_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(m32));
+    IR::U32 m_hi = ir.ArithmeticShiftRight(m32, ir.Imm8(16), ir.Imm1(0)).result;
+    if (M) {
+        std::swap(m_lo, m_hi);
+    }
+
+    const IR::U32 product_lo = ir.Mul(n_lo, m_lo);
+    const IR::U32 product_hi = ir.Mul(n_hi, m_hi);
+    const auto result_overflow = ir.AddWithCarry(product_lo, product_hi, ir.Imm1(0));
+
+    ir.SetRegister(d, result_overflow.result);
+    ir.OrQFlag(result_overflow.overflow);
     return true;
 }
 
+// SMUSD{X}<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_SMUSD(Cond cond, Reg d, Reg m, bool M, Reg n) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        const IR::U32 n32 = ir.GetRegister(n);
-        const IR::U32 m32 = ir.GetRegister(m);
-        const IR::U32 n_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(n32));
-        IR::U32 m_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(m32));
-        const IR::U32 n_hi = ir.ArithmeticShiftRight(n32, ir.Imm8(16), ir.Imm1(0)).result;
-        IR::U32 m_hi = ir.ArithmeticShiftRight(m32, ir.Imm8(16), ir.Imm1(0)).result;
-        if (M)
-            std::swap(m_lo, m_hi);
-        const IR::U32 product_lo = ir.Mul(n_lo, m_lo);
-        const IR::U32 product_hi = ir.Mul(n_hi, m_hi);
-        auto result = ir.Sub(product_lo, product_hi);
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const IR::U32 n32 = ir.GetRegister(n);
+    const IR::U32 m32 = ir.GetRegister(m);
+    const IR::U32 n_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(n32));
+    const IR::U32 n_hi = ir.ArithmeticShiftRight(n32, ir.Imm8(16), ir.Imm1(0)).result;
+
+    IR::U32 m_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(m32));
+    IR::U32 m_hi = ir.ArithmeticShiftRight(m32, ir.Imm8(16), ir.Imm1(0)).result;
+    if (M) {
+        std::swap(m_lo, m_hi);
+    }
+
+    const IR::U32 product_lo = ir.Mul(n_lo, m_lo);
+    const IR::U32 product_hi = ir.Mul(n_hi, m_hi);
+    auto result = ir.Sub(product_lo, product_hi);
+    ir.SetRegister(d, result);
     return true;
 }
 

--- a/src/frontend/A32/translate/translate_arm/packing.cpp
+++ b/src/frontend/A32/translate/translate_arm/packing.cpp
@@ -8,31 +8,39 @@
 
 namespace Dynarmic::A32 {
 
+// PKHBT<c> <Rd>, <Rn>, <Rm>{, LSL #<imm>}
 bool ArmTranslatorVisitor::arm_PKHBT(Cond cond, Reg n, Reg d, Imm5 imm5, Reg m) {
-    if (n == Reg::PC || d == Reg::PC || m == Reg::PC)
+    if (n == Reg::PC || d == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    if (ConditionPassed(cond)) {
-        auto shifted = EmitImmShift(ir.GetRegister(m), ShiftType::LSL, imm5, ir.Imm1(false)).result;
-        auto lower_half = ir.And(ir.GetRegister(n), ir.Imm32(0x0000FFFF));
-        auto upper_half = ir.And(shifted, ir.Imm32(0xFFFF0000));
-        ir.SetRegister(d, ir.Or(lower_half, upper_half));
     }
 
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto shifted = EmitImmShift(ir.GetRegister(m), ShiftType::LSL, imm5, ir.Imm1(false)).result;
+    const auto lower_half = ir.And(ir.GetRegister(n), ir.Imm32(0x0000FFFF));
+    const auto upper_half = ir.And(shifted, ir.Imm32(0xFFFF0000));
+
+    ir.SetRegister(d, ir.Or(lower_half, upper_half));
     return true;
 }
 
+// PKHTB<c> <Rd>, <Rn>, <Rm>{, ASR #<imm>}
 bool ArmTranslatorVisitor::arm_PKHTB(Cond cond, Reg n, Reg d, Imm5 imm5, Reg m) {
-    if (n == Reg::PC || d == Reg::PC || m == Reg::PC)
+    if (n == Reg::PC || d == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    if (ConditionPassed(cond)) {
-        auto shifted = EmitImmShift(ir.GetRegister(m), ShiftType::ASR, imm5, ir.Imm1(false)).result;
-        auto lower_half = ir.And(shifted, ir.Imm32(0x0000FFFF));
-        auto upper_half = ir.And(ir.GetRegister(n), ir.Imm32(0xFFFF0000));
-        ir.SetRegister(d, ir.Or(lower_half, upper_half));
     }
 
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto shifted = EmitImmShift(ir.GetRegister(m), ShiftType::ASR, imm5, ir.Imm1(false)).result;
+    const auto lower_half = ir.And(shifted, ir.Imm32(0x0000FFFF));
+    const auto upper_half = ir.And(ir.GetRegister(n), ir.Imm32(0xFFFF0000));
+
+    ir.SetRegister(d, ir.Or(lower_half, upper_half));
     return true;
 }
 

--- a/src/frontend/A32/translate/translate_arm/parallel.cpp
+++ b/src/frontend/A32/translate/translate_arm/parallel.cpp
@@ -8,359 +8,530 @@
 
 namespace Dynarmic::A32 {
 
-// Parallel Add/Subtract (Modulo arithmetic) instructions
+// SADD8<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_SADD8(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedAddS8(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result.result);
-        ir.SetGEFlags(result.ge);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedAddS8(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result.result);
+    ir.SetGEFlags(result.ge);
     return true;
 }
 
+// SADD16<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_SADD16(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedAddS16(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result.result);
-        ir.SetGEFlags(result.ge);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedAddS16(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result.result);
+    ir.SetGEFlags(result.ge);
     return true;
 }
 
+// SASX<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_SASX(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedAddSubS16(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result.result);
-        ir.SetGEFlags(result.ge);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedAddSubS16(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result.result);
+    ir.SetGEFlags(result.ge);
     return true;
 }
 
+// SSAX<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_SSAX(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedSubAddS16(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result.result);
-        ir.SetGEFlags(result.ge);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedSubAddS16(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result.result);
+    ir.SetGEFlags(result.ge);
     return true;
 }
 
+// SSUB8<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_SSUB8(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedSubS8(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result.result);
-        ir.SetGEFlags(result.ge);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedSubS8(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result.result);
+    ir.SetGEFlags(result.ge);
     return true;
 }
 
+// SSUB16<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_SSUB16(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedSubS16(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result.result);
-        ir.SetGEFlags(result.ge);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedSubS16(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result.result);
+    ir.SetGEFlags(result.ge);
     return true;
 }
 
+// UADD8<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_UADD8(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedAddU8(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result.result);
-        ir.SetGEFlags(result.ge);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedAddU8(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result.result);
+    ir.SetGEFlags(result.ge);
     return true;
 }
 
+// UADD16<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_UADD16(Cond cond, Reg n, Reg d, Reg m) {
-  if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
-      return UnpredictableInstruction();
-  if (ConditionPassed(cond)) {
-      auto result = ir.PackedAddU16(ir.GetRegister(n), ir.GetRegister(m));
-      ir.SetRegister(d, result.result);
-      ir.SetGEFlags(result.ge);
-  }
-  return true;
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
+       return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedAddU16(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result.result);
+    ir.SetGEFlags(result.ge);
+    return true;
 }
 
+// UASX<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_UASX(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedAddSubU16(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result.result);
-        ir.SetGEFlags(result.ge);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedAddSubU16(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result.result);
+    ir.SetGEFlags(result.ge);
     return true;
 }
 
+// USAX<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_USAX(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedSubAddU16(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result.result);
-        ir.SetGEFlags(result.ge);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedSubAddU16(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result.result);
+    ir.SetGEFlags(result.ge);
     return true;
 }
 
+// USAD8<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_USAD8(Cond cond, Reg d, Reg m, Reg n) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedAbsDiffSumS8(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedAbsDiffSumS8(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result);
     return true;
 }
 
+// USADA8<c> <Rd>, <Rn>, <Rm>, <Ra>
 bool ArmTranslatorVisitor::arm_USADA8(Cond cond, Reg d, Reg a, Reg m, Reg n){
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto tmp = ir.PackedAbsDiffSumS8(ir.GetRegister(n), ir.GetRegister(m));
-        auto result = ir.AddWithCarry(ir.GetRegister(a), tmp, ir.Imm1(0));
-        ir.SetRegister(d, result.result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto tmp = ir.PackedAbsDiffSumS8(ir.GetRegister(n), ir.GetRegister(m));
+    const auto result = ir.AddWithCarry(ir.GetRegister(a), tmp, ir.Imm1(0));
+    ir.SetRegister(d, result.result);
     return true;
 }
 
+// USUB8<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_USUB8(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedSubU8(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result.result);
-        ir.SetGEFlags(result.ge);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedSubU8(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result.result);
+    ir.SetGEFlags(result.ge);
     return true;
 }
 
+// USUB16<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_USUB16(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedSubU16(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result.result);
-        ir.SetGEFlags(result.ge);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedSubU16(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result.result);
+    ir.SetGEFlags(result.ge);
     return true;
 }
 
 // Parallel Add/Subtract (Saturating) instructions
+
+// QADD8<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_QADD8(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedSaturatedAddS8(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedSaturatedAddS8(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result);
     return true;
 }
 
+// QADD16<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_QADD16(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedSaturatedAddS16(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedSaturatedAddS16(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result);
     return true;
 }
 
+// QSUB8<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_QSUB8(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedSaturatedSubS8(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedSaturatedSubS8(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result);
     return true;
 }
 
+// QSUB16<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_QSUB16(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedSaturatedSubS16(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedSaturatedSubS16(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result);
     return true;
 }
 
+// UQADD8<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_UQADD8(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedSaturatedAddU8(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedSaturatedAddU8(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result);
     return true;
 }
 
+// UQADD16<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_UQADD16(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedSaturatedAddU16(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedSaturatedAddU16(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result);
     return true;
 }
 
+// UQSUB8<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_UQSUB8(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedSaturatedSubU8(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedSaturatedSubU8(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result);
     return true;
 }
 
+// UQSUB16<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_UQSUB16(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedSaturatedSubU16(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedSaturatedSubU16(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result);
     return true;
 }
 
 // Parallel Add/Subtract (Halving) instructions
+
+// SHADD8<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_SHADD8(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedHalvingAddS8(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedHalvingAddS8(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result);
     return true;
 }
 
+// SHADD16<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_SHADD16(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedHalvingAddS16(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedHalvingAddS16(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result);
     return true;
 }
 
+// SHASX<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_SHASX(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedHalvingAddSubS16(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedHalvingAddSubS16(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result);
     return true;
 }
 
+// SHSAX<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_SHSAX(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedHalvingSubAddS16(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedHalvingSubAddS16(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result);
     return true;
 }
 
+// SHSUB8<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_SHSUB8(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedHalvingSubS8(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedHalvingSubS8(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result);
     return true;
 }
 
+// SHSUB16<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_SHSUB16(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedHalvingSubS16(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedHalvingSubS16(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result);
     return true;
 }
 
+// UHADD8<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_UHADD8(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedHalvingAddU8(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedHalvingAddU8(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result);
     return true;
 }
 
+// UHADD16<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_UHADD16(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedHalvingAddU16(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedHalvingAddU16(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result);
     return true;
 }
 
+// UHASX<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_UHASX(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedHalvingAddSubU16(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedHalvingAddSubU16(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result);
     return true;
 }
 
+// UHSAX<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_UHSAX(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedHalvingSubAddU16(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedHalvingSubAddU16(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result);
     return true;
 }
 
+// UHSUB8<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_UHSUB8(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedHalvingSubU8(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedHalvingSubU8(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result);
     return true;
 }
 
+// UHSUB16<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_UHSUB16(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-    if (ConditionPassed(cond)) {
-        auto result = ir.PackedHalvingSubU16(ir.GetRegister(n), ir.GetRegister(m));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.PackedHalvingSubU16(ir.GetRegister(n), ir.GetRegister(m));
+    ir.SetRegister(d, result);
     return true;
 }
 

--- a/src/frontend/A32/translate/translate_arm/reversal.cpp
+++ b/src/frontend/A32/translate/translate_arm/reversal.cpp
@@ -8,41 +8,52 @@
 
 namespace Dynarmic::A32 {
 
+// REV<c> <Rd>, <Rm>
 bool ArmTranslatorVisitor::arm_REV(Cond cond, Reg d, Reg m) {
-    // REV<c> <Rd>, <Rm>
-    if (d == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    if (ConditionPassed(cond)) {
-        auto result = ir.ByteReverseWord(ir.GetRegister(m));
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto result = ir.ByteReverseWord(ir.GetRegister(m));
+    ir.SetRegister(d, result);
     return true;
 }
 
+// REV16<c> <Rd>, <Rm>
 bool ArmTranslatorVisitor::arm_REV16(Cond cond, Reg d, Reg m) {
-    if (d == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    if (ConditionPassed(cond)) {
-        auto reg_m = ir.GetRegister(m);
-        auto lo = ir.And(ir.LogicalShiftRight(reg_m, ir.Imm8(8), ir.Imm1(0)).result, ir.Imm32(0x00FF00FF));
-        auto hi = ir.And(ir.LogicalShiftLeft(reg_m, ir.Imm8(8), ir.Imm1(0)).result, ir.Imm32(0xFF00FF00));
-        auto result = ir.Or(lo, hi);
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto reg_m = ir.GetRegister(m);
+    const auto lo = ir.And(ir.LogicalShiftRight(reg_m, ir.Imm8(8), ir.Imm1(0)).result, ir.Imm32(0x00FF00FF));
+    const auto hi = ir.And(ir.LogicalShiftLeft(reg_m, ir.Imm8(8), ir.Imm1(0)).result, ir.Imm32(0xFF00FF00));
+    const auto result = ir.Or(lo, hi);
+
+    ir.SetRegister(d, result);
     return true;
 }
 
+// REVSH<c> <Rd>, <Rm>
 bool ArmTranslatorVisitor::arm_REVSH(Cond cond, Reg d, Reg m) {
-    // REVSH<c> <Rd>, <Rm>
-    if (d == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    if (ConditionPassed(cond)) {
-        auto rev_half = ir.ByteReverseHalf(ir.LeastSignificantHalf(ir.GetRegister(m)));
-        ir.SetRegister(d, ir.SignExtendHalfToWord(rev_half));
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto rev_half = ir.ByteReverseHalf(ir.LeastSignificantHalf(ir.GetRegister(m)));
+    ir.SetRegister(d, ir.SignExtendHalfToWord(rev_half));
     return true;
 }
 

--- a/src/frontend/A32/translate/translate_arm/saturated.cpp
+++ b/src/frontend/A32/translate/translate_arm/saturated.cpp
@@ -18,224 +18,268 @@ static IR::U16 MostSignificantHalf(A32::IREmitter& ir, IR::U32 value) {
 
 // Saturation instructions
 
+// SSAT<c> <Rd>, #<imm>, <Rn>{, <shift>}
 bool ArmTranslatorVisitor::arm_SSAT(Cond cond, Imm5 sat_imm, Reg d, Imm5 imm5, bool sh, Reg n) {
-    if (d == Reg::PC || n == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC) {
         return UnpredictableInstruction();
-
-    size_t saturate_to = static_cast<size_t>(sat_imm) + 1;
-    ShiftType shift = !sh ? ShiftType::LSL : ShiftType::ASR;
-
-    // SSAT <Rd>, #<saturate_to>, <Rn>
-    if (ConditionPassed(cond)) {
-        auto operand = EmitImmShift(ir.GetRegister(n), shift, imm5, ir.GetCFlag());
-        auto result = ir.SignedSaturation(operand.result, saturate_to);
-        ir.SetRegister(d, result.result);
-        ir.OrQFlag(result.overflow);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto saturate_to = static_cast<size_t>(sat_imm) + 1;
+    const auto shift = !sh ? ShiftType::LSL : ShiftType::ASR;
+    const auto operand = EmitImmShift(ir.GetRegister(n), shift, imm5, ir.GetCFlag());
+    const auto result = ir.SignedSaturation(operand.result, saturate_to);
+
+    ir.SetRegister(d, result.result);
+    ir.OrQFlag(result.overflow);
     return true;
 }
 
+// SSAT16<c> <Rd>, #<imm>, <Rn>
 bool ArmTranslatorVisitor::arm_SSAT16(Cond cond, Imm4 sat_imm, Reg d, Reg n) {
-    if (d == Reg::PC || n == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC) {
         return UnpredictableInstruction();
-
-    size_t saturate_to = static_cast<size_t>(sat_imm) + 1;
-
-    // SSAT16 <Rd>, #<saturate_to>, <Rn>
-    if (ConditionPassed(cond)) {
-        auto lo_operand = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(ir.GetRegister(n)));
-        auto hi_operand = ir.SignExtendHalfToWord(MostSignificantHalf(ir, ir.GetRegister(n)));
-        auto lo_result = ir.SignedSaturation(lo_operand, saturate_to);
-        auto hi_result = ir.SignedSaturation(hi_operand, saturate_to);
-        ir.SetRegister(d, Pack2x16To1x32(ir, lo_result.result, hi_result.result));
-        ir.OrQFlag(lo_result.overflow);
-        ir.OrQFlag(hi_result.overflow);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto saturate_to = static_cast<size_t>(sat_imm) + 1;
+    const auto lo_operand = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(ir.GetRegister(n)));
+    const auto hi_operand = ir.SignExtendHalfToWord(MostSignificantHalf(ir, ir.GetRegister(n)));
+    const auto lo_result = ir.SignedSaturation(lo_operand, saturate_to);
+    const auto hi_result = ir.SignedSaturation(hi_operand, saturate_to);
+
+    ir.SetRegister(d, Pack2x16To1x32(ir, lo_result.result, hi_result.result));
+    ir.OrQFlag(lo_result.overflow);
+    ir.OrQFlag(hi_result.overflow);
     return true;
 }
 
+// USAT<c> <Rd>, #<imm5>, <Rn>{, <shift>}
 bool ArmTranslatorVisitor::arm_USAT(Cond cond, Imm5 sat_imm, Reg d, Imm5 imm5, bool sh, Reg n) {
-    if (d == Reg::PC || n == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC) {
         return UnpredictableInstruction();
-
-    size_t saturate_to = static_cast<size_t>(sat_imm);
-    ShiftType shift = !sh ? ShiftType::LSL : ShiftType::ASR;
-
-    // USAT <Rd>, #<saturate_to>, <Rn>
-    if (ConditionPassed(cond)) {
-        auto operand = EmitImmShift(ir.GetRegister(n), shift, imm5, ir.GetCFlag());
-        auto result = ir.UnsignedSaturation(operand.result, saturate_to);
-        ir.SetRegister(d, result.result);
-        ir.OrQFlag(result.overflow);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto saturate_to = static_cast<size_t>(sat_imm);
+    const auto shift = !sh ? ShiftType::LSL : ShiftType::ASR;
+    const auto operand = EmitImmShift(ir.GetRegister(n), shift, imm5, ir.GetCFlag());
+    const auto result = ir.UnsignedSaturation(operand.result, saturate_to);
+
+    ir.SetRegister(d, result.result);
+    ir.OrQFlag(result.overflow);
     return true;
 }
 
+// USAT16<c> <Rd>, #<imm4>, <Rn>
 bool ArmTranslatorVisitor::arm_USAT16(Cond cond, Imm4 sat_imm, Reg d, Reg n) {
-    if (d == Reg::PC || n == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC) {
         return UnpredictableInstruction();
-
-    size_t saturate_to = static_cast<size_t>(sat_imm);
-
-    // USAT16 <Rd>, #<saturate_to>, <Rn>
-    if (ConditionPassed(cond)) {
-        // UnsignedSaturation takes a *signed* value as input, hence sign extension is required.
-        auto lo_operand = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(ir.GetRegister(n)));
-        auto hi_operand = ir.SignExtendHalfToWord(MostSignificantHalf(ir, ir.GetRegister(n)));
-        auto lo_result = ir.UnsignedSaturation(lo_operand, saturate_to);
-        auto hi_result = ir.UnsignedSaturation(hi_operand, saturate_to);
-        ir.SetRegister(d, Pack2x16To1x32(ir, lo_result.result, hi_result.result));
-        ir.OrQFlag(lo_result.overflow);
-        ir.OrQFlag(hi_result.overflow);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    // UnsignedSaturation takes a *signed* value as input, hence sign extension is required.
+    const auto saturate_to = static_cast<size_t>(sat_imm);
+    const auto lo_operand = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(ir.GetRegister(n)));
+    const auto hi_operand = ir.SignExtendHalfToWord(MostSignificantHalf(ir, ir.GetRegister(n)));
+    const auto lo_result = ir.UnsignedSaturation(lo_operand, saturate_to);
+    const auto hi_result = ir.UnsignedSaturation(hi_operand, saturate_to);
+
+    ir.SetRegister(d, Pack2x16To1x32(ir, lo_result.result, hi_result.result));
+    ir.OrQFlag(lo_result.overflow);
+    ir.OrQFlag(hi_result.overflow);
     return true;
 }
 
 // Saturated Add/Subtract instructions
 
+// QADD<c> <Rd>, <Rm>, <Rn>
 bool ArmTranslatorVisitor::arm_QADD(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    // QADD <Rd>, <Rm>, <Rn>
-    if (ConditionPassed(cond)) {
-        auto a = ir.GetRegister(m);
-        auto b = ir.GetRegister(n);
-        auto result = ir.SignedSaturatedAdd(a, b);
-        ir.SetRegister(d, result.result);
-        ir.OrQFlag(result.overflow);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto a = ir.GetRegister(m);
+    const auto b = ir.GetRegister(n);
+    const auto result = ir.SignedSaturatedAdd(a, b);
+
+    ir.SetRegister(d, result.result);
+    ir.OrQFlag(result.overflow);
     return true;
 }
 
+// QSUB<c> <Rd>, <Rm>, <Rn>
 bool ArmTranslatorVisitor::arm_QSUB(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    // QSUB <Rd>, <Rm>, <Rn>
-    if (ConditionPassed(cond)) {
-        auto a = ir.GetRegister(m);
-        auto b = ir.GetRegister(n);
-        auto result = ir.SignedSaturatedSub(a, b);
-        ir.SetRegister(d, result.result);
-        ir.OrQFlag(result.overflow);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto a = ir.GetRegister(m);
+    const auto b = ir.GetRegister(n);
+    const auto result = ir.SignedSaturatedSub(a, b);
+
+    ir.SetRegister(d, result.result);
+    ir.OrQFlag(result.overflow);
     return true;
 }
 
+// QDADD<c> <Rd>, <Rm>, <Rn>
 bool ArmTranslatorVisitor::arm_QDADD(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    // QDADD <Rd>, <Rm>, <Rn>
-    if (ConditionPassed(cond)) {
-        auto a = ir.GetRegister(m);
-        auto b = ir.GetRegister(n);
-        auto doubled = ir.SignedSaturatedAdd(b, b);
-        ir.OrQFlag(doubled.overflow);
-        auto result = ir.SignedSaturatedAdd(a, doubled.result);
-        ir.SetRegister(d, result.result);
-        ir.OrQFlag(result.overflow);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto a = ir.GetRegister(m);
+    const auto b = ir.GetRegister(n);
+    const auto doubled = ir.SignedSaturatedAdd(b, b);
+    ir.OrQFlag(doubled.overflow);
+
+    const auto result = ir.SignedSaturatedAdd(a, doubled.result);
+    ir.SetRegister(d, result.result);
+    ir.OrQFlag(result.overflow);
     return true;
 }
 
+// QDSUB<c> <Rd>, <Rm>, <Rn>
 bool ArmTranslatorVisitor::arm_QDSUB(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    // QDSUB <Rd>, <Rm>, <Rn>
-    if (ConditionPassed(cond)) {
-        auto a = ir.GetRegister(m);
-        auto b = ir.GetRegister(n);
-        auto doubled = ir.SignedSaturatedAdd(b, b);
-        ir.OrQFlag(doubled.overflow);
-        auto result = ir.SignedSaturatedSub(a, doubled.result);
-        ir.SetRegister(d, result.result);
-        ir.OrQFlag(result.overflow);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto a = ir.GetRegister(m);
+    const auto b = ir.GetRegister(n);
+    const auto doubled = ir.SignedSaturatedAdd(b, b);
+    ir.OrQFlag(doubled.overflow);
+
+    const auto result = ir.SignedSaturatedSub(a, doubled.result);
+    ir.SetRegister(d, result.result);
+    ir.OrQFlag(result.overflow);
     return true;
 }
 
 // Parallel saturated instructions
 
+// QASX<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_QASX(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    // QASX <Rd>, <Rn>, <Rm>
-    if (ConditionPassed(cond)) {
-        auto Rn = ir.GetRegister(n);
-        auto Rm = ir.GetRegister(m);
-        auto Rn_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(Rn));
-        auto Rn_hi = ir.SignExtendHalfToWord(MostSignificantHalf(ir, Rn));
-        auto Rm_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(Rm));
-        auto Rm_hi = ir.SignExtendHalfToWord(MostSignificantHalf(ir, Rm));
-        auto diff = ir.SignedSaturation(ir.Sub(Rn_lo, Rm_hi), 16).result;
-        auto sum = ir.SignedSaturation(ir.Add(Rn_hi, Rm_lo), 16).result;
-        auto result = Pack2x16To1x32(ir, diff, sum);
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto Rn = ir.GetRegister(n);
+    const auto Rm = ir.GetRegister(m);
+    const auto Rn_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(Rn));
+    const auto Rn_hi = ir.SignExtendHalfToWord(MostSignificantHalf(ir, Rn));
+    const auto Rm_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(Rm));
+    const auto Rm_hi = ir.SignExtendHalfToWord(MostSignificantHalf(ir, Rm));
+    const auto diff = ir.SignedSaturation(ir.Sub(Rn_lo, Rm_hi), 16).result;
+    const auto sum = ir.SignedSaturation(ir.Add(Rn_hi, Rm_lo), 16).result;
+    const auto result = Pack2x16To1x32(ir, diff, sum);
+
+    ir.SetRegister(d, result);
     return true;
 }
 
+// QSAX<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_QSAX(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    // QSAX <Rd>, <Rn>, <Rm>
-    if (ConditionPassed(cond)) {
-        auto Rn = ir.GetRegister(n);
-        auto Rm = ir.GetRegister(m);
-        auto Rn_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(Rn));
-        auto Rn_hi = ir.SignExtendHalfToWord(MostSignificantHalf(ir, Rn));
-        auto Rm_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(Rm));
-        auto Rm_hi = ir.SignExtendHalfToWord(MostSignificantHalf(ir, Rm));
-        auto sum = ir.SignedSaturation(ir.Add(Rn_lo, Rm_hi), 16).result;
-        auto diff = ir.SignedSaturation(ir.Sub(Rn_hi, Rm_lo), 16).result;
-        auto result = Pack2x16To1x32(ir, sum, diff);
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto Rn = ir.GetRegister(n);
+    const auto Rm = ir.GetRegister(m);
+    const auto Rn_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(Rn));
+    const auto Rn_hi = ir.SignExtendHalfToWord(MostSignificantHalf(ir, Rn));
+    const auto Rm_lo = ir.SignExtendHalfToWord(ir.LeastSignificantHalf(Rm));
+    const auto Rm_hi = ir.SignExtendHalfToWord(MostSignificantHalf(ir, Rm));
+    const auto sum = ir.SignedSaturation(ir.Add(Rn_lo, Rm_hi), 16).result;
+    const auto diff = ir.SignedSaturation(ir.Sub(Rn_hi, Rm_lo), 16).result;
+    const auto result = Pack2x16To1x32(ir, sum, diff);
+
+    ir.SetRegister(d, result);
     return true;
 }
 
+// UQASX<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_UQASX(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    // UQASX <Rd>, <Rn>, <Rm>
-    if (ConditionPassed(cond)) {
-        auto Rn = ir.GetRegister(n);
-        auto Rm = ir.GetRegister(m);
-        auto Rn_lo = ir.ZeroExtendHalfToWord(ir.LeastSignificantHalf(Rn));
-        auto Rn_hi = ir.ZeroExtendHalfToWord(MostSignificantHalf(ir, Rn));
-        auto Rm_lo = ir.ZeroExtendHalfToWord(ir.LeastSignificantHalf(Rm));
-        auto Rm_hi = ir.ZeroExtendHalfToWord(MostSignificantHalf(ir, Rm));
-        auto diff = ir.UnsignedSaturation(ir.Sub(Rn_lo, Rm_hi), 16).result;
-        auto sum = ir.UnsignedSaturation(ir.Add(Rn_hi, Rm_lo), 16).result;
-        auto result = Pack2x16To1x32(ir, diff, sum);
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto Rn = ir.GetRegister(n);
+    const auto Rm = ir.GetRegister(m);
+    const auto Rn_lo = ir.ZeroExtendHalfToWord(ir.LeastSignificantHalf(Rn));
+    const auto Rn_hi = ir.ZeroExtendHalfToWord(MostSignificantHalf(ir, Rn));
+    const auto Rm_lo = ir.ZeroExtendHalfToWord(ir.LeastSignificantHalf(Rm));
+    const auto Rm_hi = ir.ZeroExtendHalfToWord(MostSignificantHalf(ir, Rm));
+    const auto diff = ir.UnsignedSaturation(ir.Sub(Rn_lo, Rm_hi), 16).result;
+    const auto sum = ir.UnsignedSaturation(ir.Add(Rn_hi, Rm_lo), 16).result;
+    const auto result = Pack2x16To1x32(ir, diff, sum);
+
+    ir.SetRegister(d, result);
     return true;
 }
 
+// UQSAX<c> <Rd>, <Rn>, <Rm>
 bool ArmTranslatorVisitor::arm_UQSAX(Cond cond, Reg n, Reg d, Reg m) {
-    if (d == Reg::PC || n == Reg::PC || m == Reg::PC)
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();
-
-    // UQSAX <Rd>, <Rn>, <Rm>
-    if (ConditionPassed(cond)) {
-        auto Rn = ir.GetRegister(n);
-        auto Rm = ir.GetRegister(m);
-        auto Rn_lo = ir.ZeroExtendHalfToWord(ir.LeastSignificantHalf(Rn));
-        auto Rn_hi = ir.ZeroExtendHalfToWord(MostSignificantHalf(ir, Rn));
-        auto Rm_lo = ir.ZeroExtendHalfToWord(ir.LeastSignificantHalf(Rm));
-        auto Rm_hi = ir.ZeroExtendHalfToWord(MostSignificantHalf(ir, Rm));
-        auto sum = ir.UnsignedSaturation(ir.Add(Rn_lo, Rm_hi), 16).result;
-        auto diff = ir.UnsignedSaturation(ir.Sub(Rn_hi, Rm_lo), 16).result;
-        auto result = Pack2x16To1x32(ir, sum, diff);
-        ir.SetRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto Rn = ir.GetRegister(n);
+    const auto Rm = ir.GetRegister(m);
+    const auto Rn_lo = ir.ZeroExtendHalfToWord(ir.LeastSignificantHalf(Rn));
+    const auto Rn_hi = ir.ZeroExtendHalfToWord(MostSignificantHalf(ir, Rn));
+    const auto Rm_lo = ir.ZeroExtendHalfToWord(ir.LeastSignificantHalf(Rm));
+    const auto Rm_hi = ir.ZeroExtendHalfToWord(MostSignificantHalf(ir, Rm));
+    const auto sum = ir.UnsignedSaturation(ir.Add(Rn_lo, Rm_hi), 16).result;
+    const auto diff = ir.UnsignedSaturation(ir.Sub(Rn_hi, Rm_lo), 16).result;
+    const auto result = Pack2x16To1x32(ir, sum, diff);
+
+    ir.SetRegister(d, result);
     return true;
 }
 

--- a/src/frontend/A32/translate/translate_arm/status_register_access.cpp
+++ b/src/frontend/A32/translate/translate_arm/status_register_access.cpp
@@ -10,87 +10,111 @@
 
 namespace Dynarmic::A32 {
 
+// CPS<effect> <iflags>{, #<mode>}
+// CPS #<mode>
 bool ArmTranslatorVisitor::arm_CPS() {
     return InterpretThisInstruction();
 }
 
+// MRS<c> <Rd>, <spec_reg>
 bool ArmTranslatorVisitor::arm_MRS(Cond cond, Reg d) {
-    if (d == Reg::PC)
+    if (d == Reg::PC) {
         return UnpredictableInstruction();
-    // MRS <Rd>, APSR
-    if (ConditionPassed(cond)) {
-        ir.SetRegister(d, ir.GetCpsr());
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    ir.SetRegister(d, ir.GetCpsr());
     return true;
 }
 
+// MSR<c> <spec_reg>, #<const>
 bool ArmTranslatorVisitor::arm_MSR_imm(Cond cond, int mask, int rotate, Imm8 imm8) {
+    ASSERT_MSG(mask != 0, "Decode error");
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
     const bool write_nzcvq = Common::Bit<3>(mask);
     const bool write_g = Common::Bit<2>(mask);
     const bool write_e = Common::Bit<1>(mask);
     const u32 imm32 = ArmExpandImm(rotate, imm8);
-    ASSERT_MSG(mask != 0, "Decode error");
-    // MSR <spec_reg>, #<imm32>
-    if (ConditionPassed(cond)) {
-        if (write_nzcvq) {
-            ir.SetCpsrNZCVQ(ir.Imm32(imm32 & 0xF8000000));
-        }
-        if (write_g) {
-            ir.SetGEFlagsCompressed(ir.Imm32(imm32 & 0x000F0000));
-        }
-        if (write_e) {
-            const bool E = (imm32 & 0x00000200) != 0;
-            if (E != ir.current_location.EFlag()) {
-                ir.SetTerm(IR::Term::LinkBlock{ir.current_location.AdvancePC(4).SetEFlag(E)});
-                return false;
-            }
-        }
-    }
-    return true;
-}
 
-bool ArmTranslatorVisitor::arm_MSR_reg(Cond cond, int mask, Reg n) {
-    const bool write_nzcvq = Common::Bit<3>(mask);
-    const bool write_g = Common::Bit<2>(mask);
-    const bool write_e = Common::Bit<1>(mask);
-    if (mask == 0)
-        return UnpredictableInstruction();
-    if (n == Reg::PC)
-        return UnpredictableInstruction();
-    // MSR <spec_reg>, #<imm32>
-    if (ConditionPassed(cond)) {
-        const auto value = ir.GetRegister(n);
-        if (!write_e) {
-            if (write_nzcvq) {
-                ir.SetCpsrNZCVQ(ir.And(value, ir.Imm32(0xF8000000)));
-            }
-            if (write_g) {
-                ir.SetGEFlagsCompressed(ir.And(value, ir.Imm32(0x000F0000)));
-            }
-        } else {
-            const u32 cpsr_mask = (write_nzcvq ? 0xF8000000 : 0) | (write_g ? 0x000F0000 : 0) | 0x00000200;
-            const auto old_cpsr = ir.And(ir.GetCpsr(), ir.Imm32(~cpsr_mask));
-            const auto new_cpsr = ir.And(value, ir.Imm32(cpsr_mask));
-            ir.SetCpsr(ir.Or(old_cpsr, new_cpsr));
-            ir.PushRSB(ir.current_location.AdvancePC(4));
-            ir.BranchWritePC(ir.Imm32(ir.current_location.PC() + 4));
-            ir.SetTerm(IR::Term::CheckHalt{IR::Term::PopRSBHint{}});
+    if (write_nzcvq) {
+        ir.SetCpsrNZCVQ(ir.Imm32(imm32 & 0xF8000000));
+    }
+
+    if (write_g) {
+        ir.SetGEFlagsCompressed(ir.Imm32(imm32 & 0x000F0000));
+    }
+
+    if (write_e) {
+        const bool E = (imm32 & 0x00000200) != 0;
+        if (E != ir.current_location.EFlag()) {
+            ir.SetTerm(IR::Term::LinkBlock{ir.current_location.AdvancePC(4).SetEFlag(E)});
             return false;
         }
     }
+
     return true;
 }
 
+// MSR<c> <spec_reg>, <Rn>
+bool ArmTranslatorVisitor::arm_MSR_reg(Cond cond, int mask, Reg n) {
+    if (mask == 0) {
+        return UnpredictableInstruction();
+    }
+
+    if (n == Reg::PC) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const bool write_nzcvq = Common::Bit<3>(mask);
+    const bool write_g = Common::Bit<2>(mask);
+    const bool write_e = Common::Bit<1>(mask);
+    const auto value = ir.GetRegister(n);
+
+    if (!write_e) {
+        if (write_nzcvq) {
+            ir.SetCpsrNZCVQ(ir.And(value, ir.Imm32(0xF8000000)));
+        }
+
+        if (write_g) {
+            ir.SetGEFlagsCompressed(ir.And(value, ir.Imm32(0x000F0000)));
+        }
+    } else {
+        const u32 cpsr_mask = (write_nzcvq ? 0xF8000000 : 0) | (write_g ? 0x000F0000 : 0) | 0x00000200;
+        const auto old_cpsr = ir.And(ir.GetCpsr(), ir.Imm32(~cpsr_mask));
+        const auto new_cpsr = ir.And(value, ir.Imm32(cpsr_mask));
+        ir.SetCpsr(ir.Or(old_cpsr, new_cpsr));
+        ir.PushRSB(ir.current_location.AdvancePC(4));
+        ir.BranchWritePC(ir.Imm32(ir.current_location.PC() + 4));
+        ir.SetTerm(IR::Term::CheckHalt{IR::Term::PopRSBHint{}});
+        return false;
+    }
+
+    return true;
+}
+
+// RFE{<amode>} <Rn>{!}
 bool ArmTranslatorVisitor::arm_RFE() {
     return InterpretThisInstruction();
 }
 
+// SETEND <endian_specifier>
 bool ArmTranslatorVisitor::arm_SETEND(bool E) {
-    // SETEND {BE,LE}
     ir.SetTerm(IR::Term::LinkBlock{ir.current_location.AdvancePC(4).SetEFlag(E)});
     return false;
 }
 
+// SRS{<amode>} SP{!}, #<mode>
 bool ArmTranslatorVisitor::arm_SRS() {
     return InterpretThisInstruction();
 }

--- a/src/frontend/A32/translate/translate_arm/synchronization.cpp
+++ b/src/frontend/A32/translate/translate_arm/synchronization.cpp
@@ -8,151 +8,200 @@
 
 namespace Dynarmic::A32 {
 
+// CLREX
 bool ArmTranslatorVisitor::arm_CLREX() {
-    // CLREX
     ir.ClearExclusive();
     return true;
 }
 
-bool ArmTranslatorVisitor::arm_LDREX(Cond cond, Reg n, Reg d) {
-    if (d == Reg::PC || n == Reg::PC)
+// LDREX<c> <Rt>, [<Rn>]
+bool ArmTranslatorVisitor::arm_LDREX(Cond cond, Reg n, Reg t) {
+    if (t == Reg::PC || n == Reg::PC) {
         return UnpredictableInstruction();
-    // LDREX <Rd>, [<Rn>]
-    if (ConditionPassed(cond)) {
-        auto address = ir.GetRegister(n);
-        ir.SetExclusive(address, 4);
-        ir.SetRegister(d, ir.ReadMemory32(address));
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto address = ir.GetRegister(n);
+    ir.SetExclusive(address, 4);
+    ir.SetRegister(t, ir.ReadMemory32(address));
     return true;
 }
 
-bool ArmTranslatorVisitor::arm_LDREXB(Cond cond, Reg n, Reg d) {
-    if (d == Reg::PC || n == Reg::PC)
+// LDREXB<c> <Rt>, [<Rn>]
+bool ArmTranslatorVisitor::arm_LDREXB(Cond cond, Reg n, Reg t) {
+    if (t == Reg::PC || n == Reg::PC) {
         return UnpredictableInstruction();
-    // LDREXB <Rd>, [<Rn>]
-    if (ConditionPassed(cond)) {
-        auto address = ir.GetRegister(n);
-        ir.SetExclusive(address, 1);
-        ir.SetRegister(d, ir.ZeroExtendByteToWord(ir.ReadMemory8(address)));
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto address = ir.GetRegister(n);
+    ir.SetExclusive(address, 1);
+    ir.SetRegister(t, ir.ZeroExtendByteToWord(ir.ReadMemory8(address)));
     return true;
 }
 
-bool ArmTranslatorVisitor::arm_LDREXD(Cond cond, Reg n, Reg d) {
-    if (d == Reg::LR || d == Reg::PC || n == Reg::PC)
+// LDREXD<c> <Rt>, <Rt2>, [<Rn>]
+bool ArmTranslatorVisitor::arm_LDREXD(Cond cond, Reg n, Reg t) {
+    if (t == Reg::LR || t == Reg::PC || n == Reg::PC) {
         return UnpredictableInstruction();
-    // LDREXD <Rd>, <Rd1>, [<Rn>]
-    if (ConditionPassed(cond)) {
-        auto address = ir.GetRegister(n);
-        ir.SetExclusive(address, 8);
-        // DO NOT SWAP hi AND lo IN BIG ENDIAN MODE, THIS IS CORRECT BEHAVIOUR
-        auto lo = ir.ReadMemory32(address);
-        ir.SetRegister(d, lo);
-        auto hi = ir.ReadMemory32(ir.Add(address, ir.Imm32(4)));
-        ir.SetRegister(d+1, hi);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto address = ir.GetRegister(n);
+    ir.SetExclusive(address, 8);
+
+    // DO NOT SWAP hi AND lo IN BIG ENDIAN MODE, THIS IS CORRECT BEHAVIOUR
+    const auto lo = ir.ReadMemory32(address);
+    ir.SetRegister(t, lo);
+    const auto hi = ir.ReadMemory32(ir.Add(address, ir.Imm32(4)));
+    ir.SetRegister(t+1, hi);
     return true;
 }
 
-bool ArmTranslatorVisitor::arm_LDREXH(Cond cond, Reg n, Reg d) {
-    if (d == Reg::PC || n == Reg::PC)
+// LDREXH<c> <Rt>, [<Rn>]
+bool ArmTranslatorVisitor::arm_LDREXH(Cond cond, Reg n, Reg t) {
+    if (t == Reg::PC || n == Reg::PC) {
         return UnpredictableInstruction();
-    // LDREXH <Rd>, [<Rn>]
-    if (ConditionPassed(cond)) {
-        auto address = ir.GetRegister(n);
-        ir.SetExclusive(address, 2);
-        ir.SetRegister(d, ir.ZeroExtendHalfToWord(ir.ReadMemory16(address)));
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto address = ir.GetRegister(n);
+    ir.SetExclusive(address, 2);
+    ir.SetRegister(t, ir.ZeroExtendHalfToWord(ir.ReadMemory16(address)));
     return true;
 }
 
-bool ArmTranslatorVisitor::arm_STREX(Cond cond, Reg n, Reg d, Reg m) {
-    if (n == Reg::PC || d == Reg::PC || m == Reg::PC)
+// STREX<c> <Rd>, <Rt>, [<Rn>]
+bool ArmTranslatorVisitor::arm_STREX(Cond cond, Reg n, Reg d, Reg t) {
+    if (n == Reg::PC || d == Reg::PC || t == Reg::PC) {
         return UnpredictableInstruction();
-    if (d == n || d == m)
-        return UnpredictableInstruction();
-    // STREX <Rd>, <Rm>, [<Rn>]
-    if (ConditionPassed(cond)) {
-        auto address = ir.GetRegister(n);
-        auto value = ir.GetRegister(m);
-        auto passed = ir.ExclusiveWriteMemory32(address, value);
-        ir.SetRegister(d, passed);
     }
+
+    if (d == n || d == t) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto address = ir.GetRegister(n);
+    const auto value = ir.GetRegister(t);
+    const auto passed = ir.ExclusiveWriteMemory32(address, value);
+    ir.SetRegister(d, passed);
     return true;
 }
 
-bool ArmTranslatorVisitor::arm_STREXB(Cond cond, Reg n, Reg d, Reg m) {
-    if (n == Reg::PC || d == Reg::PC || m == Reg::PC)
+// STREXB<c> <Rd>, <Rt>, [<Rn>]
+bool ArmTranslatorVisitor::arm_STREXB(Cond cond, Reg n, Reg d, Reg t) {
+    if (n == Reg::PC || d == Reg::PC || t == Reg::PC) {
         return UnpredictableInstruction();
-    if (d == n || d == m)
-        return UnpredictableInstruction();
-    // STREXB <Rd>, <Rm>, [<Rn>]
-    if (ConditionPassed(cond)) {
-        auto address = ir.GetRegister(n);
-        auto value = ir.LeastSignificantByte(ir.GetRegister(m));
-        auto passed = ir.ExclusiveWriteMemory8(address, value);
-        ir.SetRegister(d, passed);
     }
+
+    if (d == n || d == t) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto address = ir.GetRegister(n);
+    const auto value = ir.LeastSignificantByte(ir.GetRegister(t));
+    const auto passed = ir.ExclusiveWriteMemory8(address, value);
+    ir.SetRegister(d, passed);
     return true;
 }
 
-bool ArmTranslatorVisitor::arm_STREXD(Cond cond, Reg n, Reg d, Reg m) {
-    if (n == Reg::PC || d == Reg::PC || m == Reg::LR || static_cast<size_t>(m) % 2 == 1)
+// STREXD<c> <Rd>, <Rt>, <Rt2>, [<Rn>]
+bool ArmTranslatorVisitor::arm_STREXD(Cond cond, Reg n, Reg d, Reg t) {
+    if (n == Reg::PC || d == Reg::PC || t == Reg::LR || static_cast<size_t>(t) % 2 == 1) {
         return UnpredictableInstruction();
-    if (d == n || d == m || d == m+1)
-        return UnpredictableInstruction();
-    Reg m2 = m + 1;
-    // STREXD <Rd>, <Rm>, <Rm2>, [<Rn>]
-    if (ConditionPassed(cond)) {
-        auto address = ir.GetRegister(n);
-        auto value_lo = ir.GetRegister(m);
-        auto value_hi = ir.GetRegister(m2);
-        auto passed = ir.ExclusiveWriteMemory64(address, value_lo, value_hi);
-        ir.SetRegister(d, passed);
     }
+
+    if (d == n || d == t || d == t+1) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const Reg t2 = t + 1;
+    const auto address = ir.GetRegister(n);
+    const auto value_lo = ir.GetRegister(t);
+    const auto value_hi = ir.GetRegister(t2);
+    const auto passed = ir.ExclusiveWriteMemory64(address, value_lo, value_hi);
+    ir.SetRegister(d, passed);
     return true;
 }
 
-bool ArmTranslatorVisitor::arm_STREXH(Cond cond, Reg n, Reg d, Reg m) {
-    if (n == Reg::PC || d == Reg::PC || m == Reg::PC)
+// STREXH<c> <Rd>, <Rt>, [<Rn>]
+bool ArmTranslatorVisitor::arm_STREXH(Cond cond, Reg n, Reg d, Reg t) {
+    if (n == Reg::PC || d == Reg::PC || t == Reg::PC) {
         return UnpredictableInstruction();
-    if (d == n || d == m)
-        return UnpredictableInstruction();
-    // STREXH <Rd>, <Rm>, [<Rn>]
-    if (ConditionPassed(cond)) {
-        auto address = ir.GetRegister(n);
-        auto value = ir.LeastSignificantHalf(ir.GetRegister(m));
-        auto passed = ir.ExclusiveWriteMemory16(address, value);
-        ir.SetRegister(d, passed);
     }
+
+    if (d == n || d == t) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto address = ir.GetRegister(n);
+    const auto value = ir.LeastSignificantHalf(ir.GetRegister(t));
+    const auto passed = ir.ExclusiveWriteMemory16(address, value);
+    ir.SetRegister(d, passed);
     return true;
 }
 
+// SWP<c> <Rt>, <Rt2>, [<Rn>]
+// TODO: UNDEFINED if current mode is Hypervisor
 bool ArmTranslatorVisitor::arm_SWP(Cond cond, Reg n, Reg t, Reg t2) {
-    if (t == Reg::PC || t2 == Reg::PC || n == Reg::PC || n == t || n == t2)
+    if (t == Reg::PC || t2 == Reg::PC || n == Reg::PC || n == t || n == t2) {
         return UnpredictableInstruction();
-    // TODO: UNDEFINED if current mode is Hypervisor
-    // SWP <Rt>, <Rt2>, [<Rn>]
-    if (ConditionPassed(cond)) {
-        auto data = ir.ReadMemory32(ir.GetRegister(n));
-        ir.WriteMemory32(ir.GetRegister(n), ir.GetRegister(t2));
-        // TODO: Alignment check
-        ir.SetRegister(t, data);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto data = ir.ReadMemory32(ir.GetRegister(n));
+    ir.WriteMemory32(ir.GetRegister(n), ir.GetRegister(t2));
+    // TODO: Alignment check
+    ir.SetRegister(t, data);
     return true;
 }
 
+// SWPB<c> <Rt>, <Rt2>, [<Rn>]
+// TODO: UNDEFINED if current mode is Hypervisor
 bool ArmTranslatorVisitor::arm_SWPB(Cond cond, Reg n, Reg t, Reg t2) {
-    if (t == Reg::PC || t2 == Reg::PC || n == Reg::PC || n == t || n == t2)
+    if (t == Reg::PC || t2 == Reg::PC || n == Reg::PC || n == t || n == t2) {
         return UnpredictableInstruction();
-    // TODO: UNDEFINED if current mode is Hypervisor
-    // SWPB <Rt>, <Rt2>, [<Rn>]
-    if (ConditionPassed(cond)) {
-        auto data = ir.ReadMemory8(ir.GetRegister(n));
-        ir.WriteMemory8(ir.GetRegister(n), ir.LeastSignificantByte(ir.GetRegister(t2)));
-        // TODO: Alignment check
-        ir.SetRegister(t, ir.ZeroExtendByteToWord(data));
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto data = ir.ReadMemory8(ir.GetRegister(n));
+    ir.WriteMemory8(ir.GetRegister(n), ir.LeastSignificantByte(ir.GetRegister(t2)));
+    // TODO: Alignment check
+    ir.SetRegister(t, ir.ZeroExtendByteToWord(data));
     return true;
 }
 

--- a/src/frontend/A32/translate/translate_arm/translate_arm.h
+++ b/src/frontend/A32/translate/translate_arm/translate_arm.h
@@ -313,16 +313,16 @@ struct ArmTranslatorVisitor final {
 
     // Synchronization Primitive instructions
     bool arm_CLREX();
-    bool arm_LDREX(Cond cond, Reg n, Reg d);
-    bool arm_LDREXB(Cond cond, Reg n, Reg d);
-    bool arm_LDREXD(Cond cond, Reg n, Reg d);
-    bool arm_LDREXH(Cond cond, Reg n, Reg d);
-    bool arm_STREX(Cond cond, Reg n, Reg d, Reg m);
-    bool arm_STREXB(Cond cond, Reg n, Reg d, Reg m);
-    bool arm_STREXD(Cond cond, Reg n, Reg d, Reg m);
-    bool arm_STREXH(Cond cond, Reg n, Reg d, Reg m);
-    bool arm_SWP(Cond cond, Reg n, Reg d, Reg m);
-    bool arm_SWPB(Cond cond, Reg n, Reg d, Reg m);
+    bool arm_LDREX(Cond cond, Reg n, Reg t);
+    bool arm_LDREXB(Cond cond, Reg n, Reg t);
+    bool arm_LDREXD(Cond cond, Reg n, Reg t);
+    bool arm_LDREXH(Cond cond, Reg n, Reg t);
+    bool arm_STREX(Cond cond, Reg n, Reg d, Reg t);
+    bool arm_STREXB(Cond cond, Reg n, Reg d, Reg t);
+    bool arm_STREXD(Cond cond, Reg n, Reg d, Reg t);
+    bool arm_STREXH(Cond cond, Reg n, Reg d, Reg t);
+    bool arm_SWP(Cond cond, Reg n, Reg t, Reg t2);
+    bool arm_SWPB(Cond cond, Reg n, Reg t, Reg t2);
 
     // Status register access instructions
     bool arm_CPS();

--- a/src/frontend/A32/translate/translate_arm/vfp2.cpp
+++ b/src/frontend/A32/translate/translate_arm/vfp2.cpp
@@ -18,15 +18,14 @@ static ExtReg ToExtReg(bool sz, size_t base, bool bit) {
 
 template <typename FnT>
 bool ArmTranslatorVisitor::EmitVfpVectorOperation(bool sz, ExtReg d, ExtReg n, ExtReg m, const FnT& fn) {
-    // VFP register banks are 8 single-precision registers in size.
-    const size_t register_bank_size = sz ? 4 : 8;
-
     if (!ir.current_location.FPSCR().Stride()) {
         return UnpredictableInstruction();
     }
 
+    // VFP register banks are 8 single-precision registers in size.
+    const size_t register_bank_size = sz ? 4 : 8;
     size_t vector_length = ir.current_location.FPSCR().Len();
-    size_t vector_stride = *ir.current_location.FPSCR().Stride();
+    const size_t vector_stride = *ir.current_location.FPSCR().Stride();
 
     // Unpredictable case
     if (vector_stride * vector_length > register_bank_size) {
@@ -35,8 +34,9 @@ bool ArmTranslatorVisitor::EmitVfpVectorOperation(bool sz, ExtReg d, ExtReg n, E
 
     // Scalar case
     if (vector_length == 1) {
-        if (vector_stride != 1)
+        if (vector_stride != 1) {
             return UnpredictableInstruction();
+        }
 
         fn(d, n, m);
         return true;
@@ -47,10 +47,10 @@ bool ArmTranslatorVisitor::EmitVfpVectorOperation(bool sz, ExtReg d, ExtReg n, E
     // * four double-precision reigsters.
     // VFP vector instructions access these registers in a circular manner.
     const auto bank_increment = [register_bank_size](ExtReg reg, size_t stride) -> ExtReg {
-        size_t reg_number = static_cast<size_t>(reg);
-        size_t bank_index = reg_number % register_bank_size;
-        size_t bank_start = reg_number - bank_index;
-        size_t next_reg_number = bank_start + ((bank_index + stride) % register_bank_size);
+        const auto reg_number = static_cast<size_t>(reg);
+        const auto bank_index = reg_number % register_bank_size;
+        const auto bank_start = reg_number - bank_index;
+        const auto next_reg_number = bank_start + ((bank_index + stride) % register_bank_size);
         return static_cast<ExtReg>(next_reg_number);
     };
 
@@ -75,8 +75,9 @@ bool ArmTranslatorVisitor::EmitVfpVectorOperation(bool sz, ExtReg d, ExtReg n, E
 
         d = bank_increment(d, vector_stride);
         n = bank_increment(n, vector_stride);
-        if (!m_is_scalar)
+        if (!m_is_scalar) {
             m = bank_increment(m, vector_stride);
+        }
     }
 
     return true;
@@ -89,675 +90,860 @@ bool ArmTranslatorVisitor::EmitVfpVectorOperation(bool sz, ExtReg d, ExtReg m, c
     });
 }
 
+// VADD<c>.F64 <Dd>, <Dn>, <Dm>
+// VADD<c>.F32 <Sd>, <Sn>, <Sm>
 bool ArmTranslatorVisitor::vfp2_VADD(Cond cond, bool D, size_t Vn, size_t Vd, bool sz, bool N, bool M, size_t Vm) {
-    ExtReg d = ToExtReg(sz, Vd, D);
-    ExtReg n = ToExtReg(sz, Vn, N);
-    ExtReg m = ToExtReg(sz, Vm, M);
-    // VADD.{F32,F64} <{S,D}d>, <{S,D}n>, <{S,D}m>
-    if (ConditionPassed(cond)) {
-        return EmitVfpVectorOperation(sz, d, n, m, [this](ExtReg d, ExtReg n, ExtReg m) {
-            auto reg_n = ir.GetExtendedRegister(n);
-            auto reg_m = ir.GetExtendedRegister(m);
-            auto result = ir.FPAdd(reg_n, reg_m, true);
-            ir.SetExtendedRegister(d, result);
-        });
+    if (!ConditionPassed(cond)) {
+        return true;
     }
-    return true;
+
+    const auto d = ToExtReg(sz, Vd, D);
+    const auto n = ToExtReg(sz, Vn, N);
+    const auto m = ToExtReg(sz, Vm, M);
+
+    return EmitVfpVectorOperation(sz, d, n, m, [this](ExtReg d, ExtReg n, ExtReg m) {
+        const auto reg_n = ir.GetExtendedRegister(n);
+        const auto reg_m = ir.GetExtendedRegister(m);
+        const auto result = ir.FPAdd(reg_n, reg_m, true);
+        ir.SetExtendedRegister(d, result);
+    });
 }
 
+// VSUB<c>.F64 <Dd>, <Dn>, <Dm>
+// VSUB<c>.F32 <Sd>, <Sn>, <Sm>
 bool ArmTranslatorVisitor::vfp2_VSUB(Cond cond, bool D, size_t Vn, size_t Vd, bool sz, bool N, bool M, size_t Vm) {
-    ExtReg d = ToExtReg(sz, Vd, D);
-    ExtReg n = ToExtReg(sz, Vn, N);
-    ExtReg m = ToExtReg(sz, Vm, M);
-    // VSUB.{F32,F64} <{S,D}d>, <{S,D}n>, <{S,D}m>
-    if (ConditionPassed(cond)) {
-        return EmitVfpVectorOperation(sz, d, n, m, [this](ExtReg d, ExtReg n, ExtReg m) {
-            auto reg_n = ir.GetExtendedRegister(n);
-            auto reg_m = ir.GetExtendedRegister(m);
-            auto result = ir.FPSub(reg_n, reg_m, true);
-            ir.SetExtendedRegister(d, result);
-        });
+    if (!ConditionPassed(cond)) {
+        return true;
     }
-    return true;
+
+    const auto d = ToExtReg(sz, Vd, D);
+    const auto n = ToExtReg(sz, Vn, N);
+    const auto m = ToExtReg(sz, Vm, M);
+
+    return EmitVfpVectorOperation(sz, d, n, m, [this](ExtReg d, ExtReg n, ExtReg m) {
+        const auto reg_n = ir.GetExtendedRegister(n);
+        const auto reg_m = ir.GetExtendedRegister(m);
+        const auto result = ir.FPSub(reg_n, reg_m, true);
+        ir.SetExtendedRegister(d, result);
+    });
 }
 
+// VMUL<c>.F64 <Dd>, <Dn>, <Dm>
+// VMUL<c>.F32 <Sd>, <Sn>, <Sm>
 bool ArmTranslatorVisitor::vfp2_VMUL(Cond cond, bool D, size_t Vn, size_t Vd, bool sz, bool N, bool M, size_t Vm) {
-    ExtReg d = ToExtReg(sz, Vd, D);
-    ExtReg n = ToExtReg(sz, Vn, N);
-    ExtReg m = ToExtReg(sz, Vm, M);
-    // VMUL.{F32,F64} <{S,D}d>, <{S,D}n>, <{S,D}m>
-    if (ConditionPassed(cond)) {
-        return EmitVfpVectorOperation(sz, d, n, m, [this](ExtReg d, ExtReg n, ExtReg m) {
-            auto reg_n = ir.GetExtendedRegister(n);
-            auto reg_m = ir.GetExtendedRegister(m);
-            auto result = ir.FPMul(reg_n, reg_m, true);
-            ir.SetExtendedRegister(d, result);
-        });
+    if (!ConditionPassed(cond)) {
+        return true;
     }
-    return true;
+
+    const auto d = ToExtReg(sz, Vd, D);
+    const auto n = ToExtReg(sz, Vn, N);
+    const auto m = ToExtReg(sz, Vm, M);
+
+    return EmitVfpVectorOperation(sz, d, n, m, [this](ExtReg d, ExtReg n, ExtReg m) {
+        const auto reg_n = ir.GetExtendedRegister(n);
+        const auto reg_m = ir.GetExtendedRegister(m);
+        const auto result = ir.FPMul(reg_n, reg_m, true);
+        ir.SetExtendedRegister(d, result);
+    });
 }
 
+// VMLA<c>.F64 <Dd>, <Dn>, <Dm>
+// VMLA<c>.F32 <Sd>, <Sn>, <Sm>
 bool ArmTranslatorVisitor::vfp2_VMLA(Cond cond, bool D, size_t Vn, size_t Vd, bool sz, bool N, bool M, size_t Vm) {
-    ExtReg d = ToExtReg(sz, Vd, D);
-    ExtReg n = ToExtReg(sz, Vn, N);
-    ExtReg m = ToExtReg(sz, Vm, M);
-    // VMLA.{F32,F64} <{S,D}d>, <{S,D}n>, <{S,D}m>
-    if (ConditionPassed(cond)) {
-        return EmitVfpVectorOperation(sz, d, n, m, [this](ExtReg d, ExtReg n, ExtReg m) {
-            auto reg_n = ir.GetExtendedRegister(n);
-            auto reg_m = ir.GetExtendedRegister(m);
-            auto reg_d = ir.GetExtendedRegister(d);
-            auto result = ir.FPAdd(reg_d, ir.FPMul(reg_n, reg_m, true), true);
-            ir.SetExtendedRegister(d, result);
-        });
+    if (!ConditionPassed(cond)) {
+        return true;
     }
-    return true;
+
+    const auto d = ToExtReg(sz, Vd, D);
+    const auto n = ToExtReg(sz, Vn, N);
+    const auto m = ToExtReg(sz, Vm, M);
+
+    return EmitVfpVectorOperation(sz, d, n, m, [this](ExtReg d, ExtReg n, ExtReg m) {
+        const auto reg_n = ir.GetExtendedRegister(n);
+        const auto reg_m = ir.GetExtendedRegister(m);
+        const auto reg_d = ir.GetExtendedRegister(d);
+        const auto result = ir.FPAdd(reg_d, ir.FPMul(reg_n, reg_m, true), true);
+        ir.SetExtendedRegister(d, result);
+    });
 }
 
+// VMLS<c>.F64 <Dd>, <Dn>, <Dm>
+// VMLS<c>.F32 <Sd>, <Sn>, <Sm>
 bool ArmTranslatorVisitor::vfp2_VMLS(Cond cond, bool D, size_t Vn, size_t Vd, bool sz, bool N, bool M, size_t Vm) {
-    ExtReg d = ToExtReg(sz, Vd, D);
-    ExtReg n = ToExtReg(sz, Vn, N);
-    ExtReg m = ToExtReg(sz, Vm, M);
-    // VMLS.{F32,F64} <{S,D}d>, <{S,D}n>, <{S,D}m>
-    if (ConditionPassed(cond)) {
-        return EmitVfpVectorOperation(sz, d, n, m, [this](ExtReg d, ExtReg n, ExtReg m) {
-            auto reg_n = ir.GetExtendedRegister(n);
-            auto reg_m = ir.GetExtendedRegister(m);
-            auto reg_d = ir.GetExtendedRegister(d);
-            auto result = ir.FPAdd(reg_d, ir.FPNeg(ir.FPMul(reg_n, reg_m, true)), true);
-            ir.SetExtendedRegister(d, result);
-        });
+    if (!ConditionPassed(cond)) {
+        return true;
     }
-    return true;
+
+    const auto d = ToExtReg(sz, Vd, D);
+    const auto n = ToExtReg(sz, Vn, N);
+    const auto m = ToExtReg(sz, Vm, M);
+
+    return EmitVfpVectorOperation(sz, d, n, m, [this](ExtReg d, ExtReg n, ExtReg m) {
+        const auto reg_n = ir.GetExtendedRegister(n);
+        const auto reg_m = ir.GetExtendedRegister(m);
+        const auto reg_d = ir.GetExtendedRegister(d);
+        const auto result = ir.FPAdd(reg_d, ir.FPNeg(ir.FPMul(reg_n, reg_m, true)), true);
+        ir.SetExtendedRegister(d, result);
+    });
 }
 
+// VNMUL<c>.F64 <Dd>, <Dn>, <Dm>
+// VNMUL<c>.F32 <Sd>, <Sn>, <Sm>
 bool ArmTranslatorVisitor::vfp2_VNMUL(Cond cond, bool D, size_t Vn, size_t Vd, bool sz, bool N, bool M, size_t Vm) {
-    ExtReg d = ToExtReg(sz, Vd, D);
-    ExtReg n = ToExtReg(sz, Vn, N);
-    ExtReg m = ToExtReg(sz, Vm, M);
-    // VNMUL.{F32,F64} <{S,D}d>, <{S,D}n>, <{S,D}m>
-    if (ConditionPassed(cond)) {
-        return EmitVfpVectorOperation(sz, d, n, m, [this](ExtReg d, ExtReg n, ExtReg m) {
-            auto reg_n = ir.GetExtendedRegister(n);
-            auto reg_m = ir.GetExtendedRegister(m);
-            auto result = ir.FPNeg(ir.FPMul(reg_n, reg_m, true));
-            ir.SetExtendedRegister(d, result);
-        });
+    if (!ConditionPassed(cond)) {
+        return true;
     }
-    return true;
+
+    const auto d = ToExtReg(sz, Vd, D);
+    const auto n = ToExtReg(sz, Vn, N);
+    const auto m = ToExtReg(sz, Vm, M);
+
+    return EmitVfpVectorOperation(sz, d, n, m, [this](ExtReg d, ExtReg n, ExtReg m) {
+        const auto reg_n = ir.GetExtendedRegister(n);
+        const auto reg_m = ir.GetExtendedRegister(m);
+        const auto result = ir.FPNeg(ir.FPMul(reg_n, reg_m, true));
+        ir.SetExtendedRegister(d, result);
+    });
 }
 
+// VNMLA<c>.F64 <Dd>, <Dn>, <Dm>
+// VNMLA<c>.F32 <Sd>, <Sn>, <Sm>
 bool ArmTranslatorVisitor::vfp2_VNMLA(Cond cond, bool D, size_t Vn, size_t Vd, bool sz, bool N, bool M, size_t Vm) {
-    ExtReg d = ToExtReg(sz, Vd, D);
-    ExtReg n = ToExtReg(sz, Vn, N);
-    ExtReg m = ToExtReg(sz, Vm, M);
-    // VNMLA.{F32,F64} <{S,D}d>, <{S,D}n>, <{S,D}m>
-    if (ConditionPassed(cond)) {
-        return EmitVfpVectorOperation(sz, d, n, m, [this](ExtReg d, ExtReg n, ExtReg m) {
-            auto reg_n = ir.GetExtendedRegister(n);
-            auto reg_m = ir.GetExtendedRegister(m);
-            auto reg_d = ir.GetExtendedRegister(d);
-            auto result = ir.FPAdd(ir.FPNeg(reg_d), ir.FPNeg(ir.FPMul(reg_n, reg_m, true)), true);
-            ir.SetExtendedRegister(d, result);
-        });
+    if (!ConditionPassed(cond)) {
+        return true;
     }
-    return true;
+
+    const auto d = ToExtReg(sz, Vd, D);
+    const auto n = ToExtReg(sz, Vn, N);
+    const auto m = ToExtReg(sz, Vm, M);
+
+    return EmitVfpVectorOperation(sz, d, n, m, [this](ExtReg d, ExtReg n, ExtReg m) {
+        const auto reg_n = ir.GetExtendedRegister(n);
+        const auto reg_m = ir.GetExtendedRegister(m);
+        const auto reg_d = ir.GetExtendedRegister(d);
+        const auto result = ir.FPAdd(ir.FPNeg(reg_d), ir.FPNeg(ir.FPMul(reg_n, reg_m, true)), true);
+        ir.SetExtendedRegister(d, result);
+    });
 }
 
+// VNMLS<c>.F64 <Dd>, <Dn>, <Dm>
+// VNMLS<c>.F32 <Sd>, <Sn>, <Sm>
 bool ArmTranslatorVisitor::vfp2_VNMLS(Cond cond, bool D, size_t Vn, size_t Vd, bool sz, bool N, bool M, size_t Vm) {
-    ExtReg d = ToExtReg(sz, Vd, D);
-    ExtReg n = ToExtReg(sz, Vn, N);
-    ExtReg m = ToExtReg(sz, Vm, M);
-    // VNMLS.{F32,F64} <{S,D}d>, <{S,D}n>, <{S,D}m>
-    if (ConditionPassed(cond)) {
-        return EmitVfpVectorOperation(sz, d, n, m, [this](ExtReg d, ExtReg n, ExtReg m) {
-            auto reg_n = ir.GetExtendedRegister(n);
-            auto reg_m = ir.GetExtendedRegister(m);
-            auto reg_d = ir.GetExtendedRegister(d);
-            auto result = ir.FPAdd(ir.FPNeg(reg_d), ir.FPMul(reg_n, reg_m, true), true);
-            ir.SetExtendedRegister(d, result);
-        });
+    if (!ConditionPassed(cond)) {
+        return true;
     }
-    return true;
+
+    const auto d = ToExtReg(sz, Vd, D);
+    const auto n = ToExtReg(sz, Vn, N);
+    const auto m = ToExtReg(sz, Vm, M);
+
+    return EmitVfpVectorOperation(sz, d, n, m, [this](ExtReg d, ExtReg n, ExtReg m) {
+        const auto reg_n = ir.GetExtendedRegister(n);
+        const auto reg_m = ir.GetExtendedRegister(m);
+        const auto reg_d = ir.GetExtendedRegister(d);
+        const auto result = ir.FPAdd(ir.FPNeg(reg_d), ir.FPMul(reg_n, reg_m, true), true);
+        ir.SetExtendedRegister(d, result);
+    });
 }
 
+// VDIV<c>.F64 <Dd>, <Dn>, <Dm>
+// VDIV<c>.F32 <Sd>, <Sn>, <Sm>
 bool ArmTranslatorVisitor::vfp2_VDIV(Cond cond, bool D, size_t Vn, size_t Vd, bool sz, bool N, bool M, size_t Vm) {
-    ExtReg d = ToExtReg(sz, Vd, D);
-    ExtReg n = ToExtReg(sz, Vn, N);
-    ExtReg m = ToExtReg(sz, Vm, M);
-    // VDIV.{F32,F64} <{S,D}d>, <{S,D}n>, <{S,D}m>
-    if (ConditionPassed(cond)) {
-        return EmitVfpVectorOperation(sz, d, n, m, [this](ExtReg d, ExtReg n, ExtReg m) {
-            auto reg_n = ir.GetExtendedRegister(n);
-            auto reg_m = ir.GetExtendedRegister(m);
-            auto result = ir.FPDiv(reg_n, reg_m, true);
-            ir.SetExtendedRegister(d, result);
-        });
+    if (!ConditionPassed(cond)) {
+        return true;
     }
-    return true;
+
+    const auto d = ToExtReg(sz, Vd, D);
+    const auto n = ToExtReg(sz, Vn, N);
+    const auto m = ToExtReg(sz, Vm, M);
+
+    return EmitVfpVectorOperation(sz, d, n, m, [this](ExtReg d, ExtReg n, ExtReg m) {
+        const auto reg_n = ir.GetExtendedRegister(n);
+        const auto reg_m = ir.GetExtendedRegister(m);
+        const auto result = ir.FPDiv(reg_n, reg_m, true);
+        ir.SetExtendedRegister(d, result);
+    });
 }
 
+// VMOV<c>.32 <Dd[0]>, <Rt>
 bool ArmTranslatorVisitor::vfp2_VMOV_u32_f64(Cond cond, size_t Vd, Reg t, bool D) {
-    ExtReg d = ToExtReg(true, Vd, D);
-    if (t == Reg::PC)
+    if (t == Reg::PC) {
         return UnpredictableInstruction();
-    // VMOV.32 <Dd[0]>, <Rt>
-    if (ConditionPassed(cond)) {
-        auto reg_d = ir.GetExtendedRegister(d);
-        auto reg_t = ir.GetRegister(t);
-        auto result = ir.Pack2x32To1x64(reg_t, ir.MostSignificantWord(reg_d).result);
-
-        ir.SetExtendedRegister(d, result);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto d = ToExtReg(true, Vd, D);
+    const auto reg_d = ir.GetExtendedRegister(d);
+    const auto reg_t = ir.GetRegister(t);
+    const auto result = ir.Pack2x32To1x64(reg_t, ir.MostSignificantWord(reg_d).result);
+
+    ir.SetExtendedRegister(d, result);
     return true;
 }
 
+// VMOV<c>.32 <Rt>, <Dn[0]>
 bool ArmTranslatorVisitor::vfp2_VMOV_f64_u32(Cond cond, size_t Vn, Reg t, bool N) {
-    ExtReg n = ToExtReg(true, Vn, N);
-    if (t == Reg::PC)
+    if (t == Reg::PC) {
         return UnpredictableInstruction();
-    // VMOV.32 <Rt>, <Dn[0]>
-    if (ConditionPassed(cond)) {
-        auto reg_n = ir.GetExtendedRegister(n);
-        ir.SetRegister(t, ir.LeastSignificantWord(reg_n));
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto n = ToExtReg(true, Vn, N);
+    const auto reg_n = ir.GetExtendedRegister(n);
+    ir.SetRegister(t, ir.LeastSignificantWord(reg_n));
     return true;
 }
 
+// VMOV<c> <Sn>, <Rt>
 bool ArmTranslatorVisitor::vfp2_VMOV_u32_f32(Cond cond, size_t Vn, Reg t, bool N) {
-    ExtReg n = ToExtReg(false, Vn, N);
-    if (t == Reg::PC)
+    if (t == Reg::PC) {
         return UnpredictableInstruction();
-    // VMOV <Sn>, <Rt>
-    if (ConditionPassed(cond)) {
-        ir.SetExtendedRegister(n, ir.GetRegister(t));
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto n = ToExtReg(false, Vn, N);
+    ir.SetExtendedRegister(n, ir.GetRegister(t));
     return true;
 }
 
+// VMOV<c> <Rt>, <Sn>
 bool ArmTranslatorVisitor::vfp2_VMOV_f32_u32(Cond cond, size_t Vn, Reg t, bool N) {
-    ExtReg n = ToExtReg(false, Vn, N);
-    if (t == Reg::PC)
+    if (t == Reg::PC) {
         return UnpredictableInstruction();
-    // VMOV <Rt>, <Sn>
-    if (ConditionPassed(cond)) {
-        ir.SetRegister(t, ir.GetExtendedRegister(n));
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto n = ToExtReg(false, Vn, N);
+    ir.SetRegister(t, ir.GetExtendedRegister(n));
     return true;
 }
 
+// VMOV<c> <Sm>, <Sm1>, <Rt>, <Rt2>
 bool ArmTranslatorVisitor::vfp2_VMOV_2u32_2f32(Cond cond, Reg t2, Reg t, bool M, size_t Vm) {
-    ExtReg m = ToExtReg(false, Vm, M);
-    if (t == Reg::PC || t2 == Reg::PC || m == ExtReg::S31)
+    const auto m = ToExtReg(false, Vm, M);
+    if (t == Reg::PC || t2 == Reg::PC || m == ExtReg::S31) {
         return UnpredictableInstruction();
-    // VMOV <Sm>, <Sm1>, <Rt>, <Rt2>
-    if (ConditionPassed(cond)) {
-        ir.SetExtendedRegister(m, ir.GetRegister(t));
-        ir.SetExtendedRegister(m+1, ir.GetRegister(t2));
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    ir.SetExtendedRegister(m, ir.GetRegister(t));
+    ir.SetExtendedRegister(m+1, ir.GetRegister(t2));
     return true;
 }
 
+// VMOV<c> <Rt>, <Rt2>, <Sm>, <Sm1>
 bool ArmTranslatorVisitor::vfp2_VMOV_2f32_2u32(Cond cond, Reg t2, Reg t, bool M, size_t Vm) {
-    ExtReg m = ToExtReg(false, Vm, M);
-    if (t == Reg::PC || t2 == Reg::PC || m == ExtReg::S31)
+    const auto m = ToExtReg(false, Vm, M);
+    if (t == Reg::PC || t2 == Reg::PC || m == ExtReg::S31) {
         return UnpredictableInstruction();
-    if (t == t2)
-        return UnpredictableInstruction();
-    // VMOV <Rt>, <Rt2>, <Sm>, <Sm1>
-    if (ConditionPassed(cond)) {
-        ir.SetRegister(t, ir.GetExtendedRegister(m));
-        ir.SetRegister(t2, ir.GetExtendedRegister(m+1));
     }
+
+    if (t == t2) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    ir.SetRegister(t, ir.GetExtendedRegister(m));
+    ir.SetRegister(t2, ir.GetExtendedRegister(m+1));
     return true;
 }
 
+// VMOV<c> <Dm>, <Rt>, <Rt2>
 bool ArmTranslatorVisitor::vfp2_VMOV_2u32_f64(Cond cond, Reg t2, Reg t, bool M, size_t Vm) {
-    ExtReg m = ToExtReg(true, Vm, M);
-    if (t == Reg::PC || t2 == Reg::PC || m == ExtReg::S31)
+    const auto m = ToExtReg(true, Vm, M);
+    if (t == Reg::PC || t2 == Reg::PC || m == ExtReg::S31) {
         return UnpredictableInstruction();
-    // VMOV<c> <Dm>, <Rt>, <Rt2>
-    if (ConditionPassed(cond)) {
-        auto value = ir.Pack2x32To1x64(ir.GetRegister(t), ir.GetRegister(t2));
-        ir.SetExtendedRegister(m, value);
     }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto value = ir.Pack2x32To1x64(ir.GetRegister(t), ir.GetRegister(t2));
+    ir.SetExtendedRegister(m, value);
     return true;
 }
 
+// VMOV<c> <Rt>, <Rt2>, <Dm>
 bool ArmTranslatorVisitor::vfp2_VMOV_f64_2u32(Cond cond, Reg t2, Reg t, bool M, size_t Vm) {
-    ExtReg m = ToExtReg(true, Vm, M);
-    if (t == Reg::PC || t2 == Reg::PC || m == ExtReg::S31)
+    const auto m = ToExtReg(true, Vm, M);
+    if (t == Reg::PC || t2 == Reg::PC || m == ExtReg::S31) {
         return UnpredictableInstruction();
-    if (t == t2)
-        return UnpredictableInstruction();
-    // VMOV<c> <Rt>, <Rt2>, <Dm>
-    if (ConditionPassed(cond)) {
-        auto value = ir.GetExtendedRegister(m);
-        ir.SetRegister(t, ir.LeastSignificantWord(value));
-        ir.SetRegister(t2, ir.MostSignificantWord(value).result);
     }
+
+    if (t == t2) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto value = ir.GetExtendedRegister(m);
+    ir.SetRegister(t, ir.LeastSignificantWord(value));
+    ir.SetRegister(t2, ir.MostSignificantWord(value).result);
     return true;
 }
 
+// VMOV<c>.F64 <Dd>, <Dm>
+// VMOV<c>.F32 <Sd>, <Sm>
 bool ArmTranslatorVisitor::vfp2_VMOV_reg(Cond cond, bool D, size_t Vd, bool sz, bool M, size_t Vm) {
-    ExtReg d = ToExtReg(sz, Vd, D);
-    ExtReg m = ToExtReg(sz, Vm, M);
-    // VMOV.{F32,F64} <{S,D}d>, <{S,D}m>
-    if (ConditionPassed(cond)) {
-        return EmitVfpVectorOperation(sz, d, m, [this](ExtReg d, ExtReg m) {
-            ir.SetExtendedRegister(d, ir.GetExtendedRegister(m));
-        });
+    if (!ConditionPassed(cond)) {
+        return true;
     }
-    return true;
+
+    const auto d = ToExtReg(sz, Vd, D);
+    const auto m = ToExtReg(sz, Vm, M);
+
+    return EmitVfpVectorOperation(sz, d, m, [this](ExtReg d, ExtReg m) {
+        ir.SetExtendedRegister(d, ir.GetExtendedRegister(m));
+    });
 }
 
+// VABS<c>.F64 <Dd>, <Dm>
+// VABS<c>.F32 <Sd>, <Sm>
 bool ArmTranslatorVisitor::vfp2_VABS(Cond cond, bool D, size_t Vd, bool sz, bool M, size_t Vm) {
-    ExtReg d = ToExtReg(sz, Vd, D);
-    ExtReg m = ToExtReg(sz, Vm, M);
-    // VABS.{F32,F64} <{S,D}d>, <{S,D}m>
-    if (ConditionPassed(cond)) {
-        return EmitVfpVectorOperation(sz, d, m, [this](ExtReg d, ExtReg m) {
-            auto reg_m = ir.GetExtendedRegister(m);
-            auto result = ir.FPAbs(reg_m);
-            ir.SetExtendedRegister(d, result);
-        });
+    if (!ConditionPassed(cond)) {
+        return true;
     }
-    return true;
+
+    const auto d = ToExtReg(sz, Vd, D);
+    const auto m = ToExtReg(sz, Vm, M);
+
+    return EmitVfpVectorOperation(sz, d, m, [this](ExtReg d, ExtReg m) {
+        const auto reg_m = ir.GetExtendedRegister(m);
+        const auto result = ir.FPAbs(reg_m);
+        ir.SetExtendedRegister(d, result);
+    });
 }
 
+// VNEG<c>.F64 <Dd>, <Dm>
+// VNEG<c>.F32 <Sd>, <Sm>
 bool ArmTranslatorVisitor::vfp2_VNEG(Cond cond, bool D, size_t Vd, bool sz, bool M, size_t Vm) {
-    ExtReg d = ToExtReg(sz, Vd, D);
-    ExtReg m = ToExtReg(sz, Vm, M);
-    // VNEG.{F32,F64} <{S,D}d>, <{S,D}m>
-    if (ConditionPassed(cond)) {
-        return EmitVfpVectorOperation(sz, d, m, [this](ExtReg d, ExtReg m) {
-            auto reg_m = ir.GetExtendedRegister(m);
-            auto result = ir.FPNeg(reg_m);
-            ir.SetExtendedRegister(d, result);
-        });
+    if (!ConditionPassed(cond)) {
+        return true;
     }
-    return true;
+
+    const auto d = ToExtReg(sz, Vd, D);
+    const auto m = ToExtReg(sz, Vm, M);
+
+    return EmitVfpVectorOperation(sz, d, m, [this](ExtReg d, ExtReg m) {
+        const auto reg_m = ir.GetExtendedRegister(m);
+        const auto result = ir.FPNeg(reg_m);
+        ir.SetExtendedRegister(d, result);
+    });
 }
 
+// VSQRT<c>.F64 <Dd>, <Dm>
+// VSQRT<c>.F32 <Sd>, <Sm>
 bool ArmTranslatorVisitor::vfp2_VSQRT(Cond cond, bool D, size_t Vd, bool sz, bool M, size_t Vm) {
-    ExtReg d = ToExtReg(sz, Vd, D);
-    ExtReg m = ToExtReg(sz, Vm, M);
-    // VSQRT.{F32,F64} <{S,D}d>, <{S,D}m>
-    if (ConditionPassed(cond)) {
-        return EmitVfpVectorOperation(sz, d, m, [this](ExtReg d, ExtReg m) {
-            auto reg_m = ir.GetExtendedRegister(m);
-            auto result = ir.FPSqrt(reg_m);
-            ir.SetExtendedRegister(d, result);
-        });
+    if (!ConditionPassed(cond)) {
+        return true;
     }
-    return true;
+
+    const auto d = ToExtReg(sz, Vd, D);
+    const auto m = ToExtReg(sz, Vm, M);
+
+    return EmitVfpVectorOperation(sz, d, m, [this](ExtReg d, ExtReg m) {
+        const auto reg_m = ir.GetExtendedRegister(m);
+        const auto result = ir.FPSqrt(reg_m);
+        ir.SetExtendedRegister(d, result);
+    });
 }
 
+// VCVT<c>.F64.F32 <Dd>, <Sm>
+// VCVT<c>.F32.F64 <Sd>, <Dm>
 bool ArmTranslatorVisitor::vfp2_VCVT_f_to_f(Cond cond, bool D, size_t Vd, bool sz, bool M, size_t Vm) {
-    ExtReg d = ToExtReg(!sz, Vd, D); // Destination is of opposite size to source
-    ExtReg m = ToExtReg(sz, Vm, M);
-    // VCVT.F64.F32 <Sd> <Dm>
-    // VCVT.F32.F64 <Dd> <Sm>
-    if (ConditionPassed(cond)) {
-        auto reg_m = ir.GetExtendedRegister(m);
-        if (sz) {
-            auto result = ir.FPDoubleToSingle(reg_m, true);
-            ir.SetExtendedRegister(d, result);
-        } else {
-            auto result = ir.FPSingleToDouble(reg_m, true);
-            ir.SetExtendedRegister(d, result);
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto d = ToExtReg(!sz, Vd, D); // Destination is of opposite size to source
+    const auto m = ToExtReg(sz, Vm, M);
+    const auto reg_m = ir.GetExtendedRegister(m);
+
+    if (sz) {
+        const auto result = ir.FPDoubleToSingle(reg_m, true);
+        ir.SetExtendedRegister(d, result);
+    } else {
+        const auto result = ir.FPSingleToDouble(reg_m, true);
+        ir.SetExtendedRegister(d, result);
+    }
+
     return true;
 }
 
+// VCVT.F32.{S32,U32} <Sd>, <Sm>
+// VCVT.F64.{S32,U32} <Sd>, <Dm>
 bool ArmTranslatorVisitor::vfp2_VCVT_to_float(Cond cond, bool D, size_t Vd, bool sz, bool is_signed, bool M, size_t Vm) {
-    ExtReg d = ToExtReg(sz, Vd, D);
-    ExtReg m = ToExtReg(false, Vm, M);
-    FP::RoundingMode rounding_mode = ir.current_location.FPSCR().RMode();
-    // VCVT.F32.{S32,U32} <Sd>, <Sm>
-    // VCVT.F64.{S32,U32} <Sd>, <Dm>
-    if (ConditionPassed(cond)) {
-        auto reg_m = ir.GetExtendedRegister(m);
-        if (sz) {
-            auto result = is_signed
-                        ? ir.FPSignedFixedToDouble(reg_m, 0, rounding_mode)
-                        : ir.FPUnsignedFixedToDouble(reg_m, 0, rounding_mode);
-            ir.SetExtendedRegister(d, result);
-        } else {
-            auto result = is_signed
-                        ? ir.FPSignedFixedToSingle(reg_m, 0, rounding_mode)
-                        : ir.FPUnsignedFixedToSingle(reg_m, 0, rounding_mode);
-            ir.SetExtendedRegister(d, result);
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto d = ToExtReg(sz, Vd, D);
+    const auto m = ToExtReg(false, Vm, M);
+    const auto rounding_mode = ir.current_location.FPSCR().RMode();
+    const auto reg_m = ir.GetExtendedRegister(m);
+
+    if (sz) {
+        const auto result = is_signed
+                          ? ir.FPSignedFixedToDouble(reg_m, 0, rounding_mode)
+                          : ir.FPUnsignedFixedToDouble(reg_m, 0, rounding_mode);
+        ir.SetExtendedRegister(d, result);
+    } else {
+        const auto result = is_signed
+                          ? ir.FPSignedFixedToSingle(reg_m, 0, rounding_mode)
+                          : ir.FPUnsignedFixedToSingle(reg_m, 0, rounding_mode);
+        ir.SetExtendedRegister(d, result);
+    }
+
     return true;
 }
 
+// VCVT{,R}.U32.F32 <Sd>, <Sm>
+// VCVT{,R}.U32.F64 <Sd>, <Dm>
 bool ArmTranslatorVisitor::vfp2_VCVT_to_u32(Cond cond, bool D, size_t Vd, bool sz, bool round_towards_zero, bool M, size_t Vm) {
-    ExtReg d = ToExtReg(false, Vd, D);
-    ExtReg m = ToExtReg(sz, Vm, M);
-    // VCVT{,R}.U32.F32 <Sd>, <Sm>
-    // VCVT{,R}.U32.F64 <Sd>, <Dm>
-    if (ConditionPassed(cond)) {
-        auto reg_m = ir.GetExtendedRegister(m);
-        auto result = ir.FPToFixedU32(reg_m, 0, round_towards_zero ? FP::RoundingMode::TowardsZero : ir.current_location.FPSCR().RMode());
-        ir.SetExtendedRegister(d, result);
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const ExtReg d = ToExtReg(false, Vd, D);
+    const ExtReg m = ToExtReg(sz, Vm, M);
+    const auto reg_m = ir.GetExtendedRegister(m);
+    const auto result = ir.FPToFixedU32(reg_m, 0, round_towards_zero ? FP::RoundingMode::TowardsZero : ir.current_location.FPSCR().RMode());
+
+    ir.SetExtendedRegister(d, result);
     return true;
 }
 
+// VCVT{,R}.S32.F32 <Sd>, <Sm>
+// VCVT{,R}.S32.F64 <Sd>, <Dm>
 bool ArmTranslatorVisitor::vfp2_VCVT_to_s32(Cond cond, bool D, size_t Vd, bool sz, bool round_towards_zero, bool M, size_t Vm) {
-    ExtReg d = ToExtReg(false, Vd, D);
-    ExtReg m = ToExtReg(sz, Vm, M);
-    // VCVT{,R}.S32.F32 <Sd>, <Sm>
-    // VCVT{,R}.S32.F64 <Sd>, <Dm>
-    if (ConditionPassed(cond)) {
-        auto reg_m = ir.GetExtendedRegister(m);
-        auto result = ir.FPToFixedS32(reg_m, 0, round_towards_zero ? FP::RoundingMode::TowardsZero : ir.current_location.FPSCR().RMode());
-        ir.SetExtendedRegister(d, result);
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    const auto d = ToExtReg(false, Vd, D);
+    const auto m = ToExtReg(sz, Vm, M);
+    const auto reg_m = ir.GetExtendedRegister(m);
+    const auto result = ir.FPToFixedS32(reg_m, 0, round_towards_zero ? FP::RoundingMode::TowardsZero : ir.current_location.FPSCR().RMode());
+
+    ir.SetExtendedRegister(d, result);
     return true;
 }
 
+// VCMP{E}.F32 <Sd>, <Sm>
+// VCMP{E}.F64 <Dd>, <Dm>
 bool ArmTranslatorVisitor::vfp2_VCMP(Cond cond, bool D, size_t Vd, bool sz, bool E, bool M, size_t Vm) {
-    ExtReg d = ToExtReg(sz, Vd, D);
-    ExtReg m = ToExtReg(sz, Vm, M);
-    bool exc_on_qnan = E;
-    // VCMP{E}.F32 <Sd>, <Sm>
-    // VCMP{E}.F64 <Dd>, <Dm>
-    if (ConditionPassed(cond)) {
-        auto reg_d = ir.GetExtendedRegister(d);
-        auto reg_m = ir.GetExtendedRegister(m);
-        auto nzcv = ir.FPCompare(reg_d, reg_m, exc_on_qnan, true);
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto d = ToExtReg(sz, Vd, D);
+    const auto m = ToExtReg(sz, Vm, M);
+    const auto exc_on_qnan = E;
+    const auto reg_d = ir.GetExtendedRegister(d);
+    const auto reg_m = ir.GetExtendedRegister(m);
+    const auto nzcv = ir.FPCompare(reg_d, reg_m, exc_on_qnan, true);
+
+    ir.SetFpscrNZCV(nzcv);
+    return true;
+}
+
+// VCMP{E}.F32 <Sd>, #0.0
+// VCMP{E}.F64 <Dd>, #0.0
+bool ArmTranslatorVisitor::vfp2_VCMP_zero(Cond cond, bool D, size_t Vd, bool sz, bool E) {
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const auto d = ToExtReg(sz, Vd, D);
+    const auto exc_on_qnan = E;
+    const auto reg_d = ir.GetExtendedRegister(d);
+
+    if (sz) {
+        const auto nzcv = ir.FPCompare(reg_d, ir.Imm64(0), exc_on_qnan, true);
+        ir.SetFpscrNZCV(nzcv);
+    } else {
+        const auto nzcv = ir.FPCompare(reg_d, ir.Imm32(0), exc_on_qnan, true);
         ir.SetFpscrNZCV(nzcv);
     }
+
     return true;
 }
 
-bool ArmTranslatorVisitor::vfp2_VCMP_zero(Cond cond, bool D, size_t Vd, bool sz, bool E) {
-    ExtReg d = ToExtReg(sz, Vd, D);
-    bool exc_on_qnan = E;
-    // VCMP{E}.F32 <Sd>, #0.0
-    // VCMP{E}.F64 <Dd>, #0.0
-    if (ConditionPassed(cond)) {
-        auto reg_d = ir.GetExtendedRegister(d);
-        if (sz) {
-            auto nzcv = ir.FPCompare(reg_d, ir.Imm64(0), exc_on_qnan, true);
-            ir.SetFpscrNZCV(nzcv);
-        } else {
-            auto nzcv = ir.FPCompare(reg_d, ir.Imm32(0), exc_on_qnan, true);
-            ir.SetFpscrNZCV(nzcv);
-        }
-    }
-    return true;
-}
-
+// VMSR FPSCR, <Rt>
 bool ArmTranslatorVisitor::vfp2_VMSR(Cond cond, Reg t) {
-    if (t == Reg::PC)
+    if (t == Reg::PC) {
         return UnpredictableInstruction();
-
-    // VMSR FPSCR, <Rt>
-    if (ConditionPassed(cond)) {
-        ir.PushRSB(ir.current_location.AdvancePC(4)); // TODO: Replace this with a local cache.
-        ir.SetFpscr(ir.GetRegister(t));
-        ir.BranchWritePC(ir.Imm32(ir.current_location.PC() + 4));
-        ir.SetTerm(IR::Term::PopRSBHint{});
-        return false;
     }
-    return true;
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    // TODO: Replace this with a local cache.
+    ir.PushRSB(ir.current_location.AdvancePC(4));
+
+    ir.SetFpscr(ir.GetRegister(t));
+    ir.BranchWritePC(ir.Imm32(ir.current_location.PC() + 4));
+    ir.SetTerm(IR::Term::PopRSBHint{});
+    return false;
 }
 
+// VMRS <Rt>, FPSCR
 bool ArmTranslatorVisitor::vfp2_VMRS(Cond cond, Reg t) {
-    // VMRS <Rt>, FPSCR
-    if (ConditionPassed(cond)) {
-        if (t == Reg::R15) {
-            // This encodes ASPR_nzcv access
-            auto nzcv = ir.GetFpscrNZCV();
-            ir.SetCpsrNZCV(nzcv);
-        } else {
-            ir.SetRegister(t, ir.GetFpscr());
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
+
+    if (t == Reg::R15) {
+        // This encodes ASPR_nzcv access
+        const auto nzcv = ir.GetFpscrNZCV();
+        ir.SetCpsrNZCV(nzcv);
+    } else {
+        ir.SetRegister(t, ir.GetFpscr());
+    }
+
     return true;
 }
 
+// VPOP.{F32,F64} <list>
 bool ArmTranslatorVisitor::vfp2_VPOP(Cond cond, bool D, size_t Vd, bool sz, Imm8 imm8) {
     const ExtReg d = ToExtReg(sz, Vd, D);
     const size_t regs = sz ? imm8 >> 1 : imm8;
 
-    if (regs == 0 || RegNumber(d)+regs > 32)
+    if (regs == 0 || RegNumber(d)+regs > 32) {
         return UnpredictableInstruction();
-    if (sz && regs > 16)
-        return UnpredictableInstruction();
-
-    // VPOP.{F32,F64} <list>
-    if (ConditionPassed(cond)) {
-        auto address = ir.GetRegister(Reg::SP);
-
-        for (size_t i = 0; i < regs; ++i) {
-            if (sz) {
-                auto lo = ir.ReadMemory32(address);
-                address = ir.Add(address, ir.Imm32(4));
-                auto hi = ir.ReadMemory32(address);
-                address = ir.Add(address, ir.Imm32(4));
-                if (ir.current_location.EFlag()) std::swap(lo, hi);
-                ir.SetExtendedRegister(d + i, ir.Pack2x32To1x64(lo, hi));
-            } else {
-                auto res = ir.ReadMemory32(address);
-                ir.SetExtendedRegister(d + i, res);
-                address = ir.Add(address, ir.Imm32(4));
-            }
-        }
-
-        ir.SetRegister(Reg::SP, address);
     }
+
+    if (sz && regs > 16) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    auto address = ir.GetRegister(Reg::SP);
+
+    for (size_t i = 0; i < regs; ++i) {
+        if (sz) {
+            auto lo = ir.ReadMemory32(address);
+            address = ir.Add(address, ir.Imm32(4));
+            auto hi = ir.ReadMemory32(address);
+            address = ir.Add(address, ir.Imm32(4));
+            if (ir.current_location.EFlag()) {
+                std::swap(lo, hi);
+            }
+            ir.SetExtendedRegister(d + i, ir.Pack2x32To1x64(lo, hi));
+        } else {
+            const auto res = ir.ReadMemory32(address);
+            ir.SetExtendedRegister(d + i, res);
+            address = ir.Add(address, ir.Imm32(4));
+        }
+    }
+
+    ir.SetRegister(Reg::SP, address);
     return true;
 }
 
+// VPUSH.{F32,F64} <list>
 bool ArmTranslatorVisitor::vfp2_VPUSH(Cond cond, bool D, size_t Vd, bool sz, Imm8 imm8) {
-    u32 imm32 = imm8 << 2;
     const ExtReg d = ToExtReg(sz, Vd, D);
     const size_t regs = sz ? imm8 >> 1 : imm8;
 
-    if (regs == 0 || RegNumber(d)+regs > 32)
+    if (regs == 0 || RegNumber(d)+regs > 32) {
         return UnpredictableInstruction();
-    if (sz && regs > 16)
+    }
+
+    if (sz && regs > 16) {
         return UnpredictableInstruction();
-
-    // VPUSH.{F32,F64} <list>
-    if (ConditionPassed(cond)) {
-        auto address = ir.Sub(ir.GetRegister(Reg::SP), ir.Imm32(imm32));
-        ir.SetRegister(Reg::SP, address);
-
-        for (size_t i = 0; i < regs; ++i) {
-            if (sz) {
-                const auto reg_d = ir.GetExtendedRegister(d + i);
-                auto lo = ir.LeastSignificantWord(reg_d);
-                auto hi = ir.MostSignificantWord(reg_d).result;
-                if (ir.current_location.EFlag()) std::swap(lo, hi);
-                ir.WriteMemory32(address, lo);
-                address = ir.Add(address, ir.Imm32(4));
-                ir.WriteMemory32(address, hi);
-                address = ir.Add(address, ir.Imm32(4));
-            } else {
-                ir.WriteMemory32(address, ir.GetExtendedRegister(d + i));
-                address = ir.Add(address, ir.Imm32(4));
-            }
-        }
     }
-    return true;
-}
 
-bool ArmTranslatorVisitor::vfp2_VLDR(Cond cond, bool U, bool D, Reg n, size_t Vd, bool sz, Imm8 imm8) {
-    u32 imm32 = imm8 << 2;
-    ExtReg d = ToExtReg(sz, Vd, D);
-    // VLDR <{S,D}d>, [<Rn>, #+/-<imm32>]
-    if (ConditionPassed(cond)) {
-        auto base = n == Reg::PC ? ir.Imm32(ir.AlignPC(4)) : ir.GetRegister(n);
-        auto address = U ? ir.Add(base, ir.Imm32(imm32)) : ir.Sub(base, ir.Imm32(imm32));
-        if (sz) {
-            auto lo = ir.ReadMemory32(address);
-            auto hi = ir.ReadMemory32(ir.Add(address, ir.Imm32(4)));
-            if (ir.current_location.EFlag()) std::swap(lo, hi);
-            ir.SetExtendedRegister(d, ir.Pack2x32To1x64(lo, hi));
-        } else {
-            ir.SetExtendedRegister(d, ir.ReadMemory32(address));
-        }
+    if (!ConditionPassed(cond)) {
+        return true;
     }
-    return true;
-}
 
-bool ArmTranslatorVisitor::vfp2_VSTR(Cond cond, bool U, bool D, Reg n, size_t Vd, bool sz, Imm8 imm8) {
-    u32 imm32 = imm8 << 2;
-    ExtReg d = ToExtReg(sz, Vd, D);
-    // VSTR <{S,D}d>, [<Rn>, #+/-<imm32>]
-    if (ConditionPassed(cond)) {
-        auto base = n == Reg::PC ? ir.Imm32(ir.AlignPC(4)) : ir.GetRegister(n);
-        auto address = U ? ir.Add(base, ir.Imm32(imm32)) : ir.Sub(base, ir.Imm32(imm32));
+    const u32 imm32 = imm8 << 2;
+    auto address = ir.Sub(ir.GetRegister(Reg::SP), ir.Imm32(imm32));
+    ir.SetRegister(Reg::SP, address);
+
+    for (size_t i = 0; i < regs; ++i) {
         if (sz) {
-            auto reg_d = ir.GetExtendedRegister(d);
+            const auto reg_d = ir.GetExtendedRegister(d + i);
             auto lo = ir.LeastSignificantWord(reg_d);
             auto hi = ir.MostSignificantWord(reg_d).result;
             if (ir.current_location.EFlag()) std::swap(lo, hi);
             ir.WriteMemory32(address, lo);
-            ir.WriteMemory32(ir.Add(address, ir.Imm32(4)), hi);
+            address = ir.Add(address, ir.Imm32(4));
+            ir.WriteMemory32(address, hi);
+            address = ir.Add(address, ir.Imm32(4));
         } else {
-            ir.WriteMemory32(address, ir.GetExtendedRegister(d));
+            ir.WriteMemory32(address, ir.GetExtendedRegister(d + i));
+            address = ir.Add(address, ir.Imm32(4));
         }
     }
+
     return true;
 }
 
+// VLDR<c> <Dd>, [<Rn>{, #+/-<imm>}]
+// VLDR<c> <Sd>, [<Rn>{, #+/-<imm>}]
+bool ArmTranslatorVisitor::vfp2_VLDR(Cond cond, bool U, bool D, Reg n, size_t Vd, bool sz, Imm8 imm8) {
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const u32 imm32 = imm8 << 2;
+    const auto d = ToExtReg(sz, Vd, D);
+    const auto base = n == Reg::PC ? ir.Imm32(ir.AlignPC(4)) : ir.GetRegister(n);
+    const auto address = U ? ir.Add(base, ir.Imm32(imm32)) : ir.Sub(base, ir.Imm32(imm32));
+
+    if (sz) {
+        auto lo = ir.ReadMemory32(address);
+        auto hi = ir.ReadMemory32(ir.Add(address, ir.Imm32(4)));
+        if (ir.current_location.EFlag()) {
+            std::swap(lo, hi);
+        }
+        ir.SetExtendedRegister(d, ir.Pack2x32To1x64(lo, hi));
+    } else {
+        ir.SetExtendedRegister(d, ir.ReadMemory32(address));
+    }
+
+    return true;
+}
+
+// VSTR<c> <Dd>, [<Rn>{, #+/-<imm>}]
+// VSTR<c> <Sd>, [<Rn>{, #+/-<imm>}]
+bool ArmTranslatorVisitor::vfp2_VSTR(Cond cond, bool U, bool D, Reg n, size_t Vd, bool sz, Imm8 imm8) {
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const u32 imm32 = imm8 << 2;
+    const auto d = ToExtReg(sz, Vd, D);
+    const auto base = n == Reg::PC ? ir.Imm32(ir.AlignPC(4)) : ir.GetRegister(n);
+    const auto address = U ? ir.Add(base, ir.Imm32(imm32)) : ir.Sub(base, ir.Imm32(imm32));
+    if (sz) {
+        const auto reg_d = ir.GetExtendedRegister(d);
+        auto lo = ir.LeastSignificantWord(reg_d);
+        auto hi = ir.MostSignificantWord(reg_d).result;
+        if (ir.current_location.EFlag()) {
+            std::swap(lo, hi);
+        }
+        ir.WriteMemory32(address, lo);
+        ir.WriteMemory32(ir.Add(address, ir.Imm32(4)), hi);
+    } else {
+        ir.WriteMemory32(address, ir.GetExtendedRegister(d));
+    }
+
+    return true;
+}
+
+// VSTM{mode}<c> <Rn>{!}, <list of double registers>
 bool ArmTranslatorVisitor::vfp2_VSTM_a1(Cond cond, bool p, bool u, bool D, bool w, Reg n, size_t Vd, Imm8 imm8) {
-    if (!p && !u && !w)
+    if (!p && !u && !w) {
         ASSERT_MSG(false, "Decode error");
-    if (p && !w)
-        ASSERT_MSG(false, "Decode error");
-    if (p == u && w)
-        return arm_UDF();
-    if (n == Reg::PC && w)
-        return UnpredictableInstruction();
-
-    ExtReg d = ToExtReg(true, Vd, D);
-    u32 imm32 = imm8 << 2;
-    size_t regs = imm8 / 2;
-
-    if (regs == 0 || regs > 16 || A32::RegNumber(d)+regs > 32)
-        return UnpredictableInstruction();
-
-    // VSTM<mode>.F64 <Rn>{!}, <list of double registers>
-    if (ConditionPassed(cond)) {
-        auto address = u ? ir.GetRegister(n) : IR::U32(ir.Sub(ir.GetRegister(n), ir.Imm32(imm32)));
-        if (w)
-            ir.SetRegister(n, u ? IR::U32(ir.Add(address, ir.Imm32(imm32))) : address);
-        for (size_t i = 0; i < regs; i++) {
-            auto value = ir.GetExtendedRegister(d + i);
-            auto word1 = ir.LeastSignificantWord(value);
-            auto word2 = ir.MostSignificantWord(value).result;
-            if (ir.current_location.EFlag()) std::swap(word1, word2);
-            ir.WriteMemory32(address, word1);
-            address = ir.Add(address, ir.Imm32(4));
-            ir.WriteMemory32(address, word2);
-            address = ir.Add(address, ir.Imm32(4));
-        }
     }
+    
+    if (p && !w) {
+        ASSERT_MSG(false, "Decode error");
+    }
+
+    if (p == u && w) {
+        return arm_UDF();
+    }
+
+    if (n == Reg::PC && w) {
+        return UnpredictableInstruction();
+    }
+
+    const auto d = ToExtReg(true, Vd, D);
+    const size_t regs = imm8 / 2;
+
+    if (regs == 0 || regs > 16 || A32::RegNumber(d)+regs > 32) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const u32 imm32 = imm8 << 2;
+    auto address = u ? ir.GetRegister(n) : IR::U32(ir.Sub(ir.GetRegister(n), ir.Imm32(imm32)));
+    if (w) {
+        ir.SetRegister(n, u ? IR::U32(ir.Add(address, ir.Imm32(imm32))) : address);
+    }
+    for (size_t i = 0; i < regs; i++) {
+        const auto value = ir.GetExtendedRegister(d + i);
+        auto word1 = ir.LeastSignificantWord(value);
+        auto word2 = ir.MostSignificantWord(value).result;
+
+        if (ir.current_location.EFlag()) {
+            std::swap(word1, word2);
+        }
+
+        ir.WriteMemory32(address, word1);
+        address = ir.Add(address, ir.Imm32(4));
+        ir.WriteMemory32(address, word2);
+        address = ir.Add(address, ir.Imm32(4));
+    }
+
     return true;
 }
 
+// VSTM{mode}<c> <Rn>{!}, <list of single registers>
 bool ArmTranslatorVisitor::vfp2_VSTM_a2(Cond cond, bool p, bool u, bool D, bool w, Reg n, size_t Vd, Imm8 imm8) {
-    if (!p && !u && !w)
+    if (!p && !u && !w) {
         ASSERT_MSG(false, "Decode error");
-    if (p && !w)
-        ASSERT_MSG(false, "Decode error");
-    if (p == u && w)
-        return arm_UDF();
-    if (n == Reg::PC && w)
-        return UnpredictableInstruction();
-
-    ExtReg d = ToExtReg(false, Vd, D);
-    u32 imm32 = imm8 << 2;
-    size_t regs = imm8;
-
-    if (regs == 0 || A32::RegNumber(d)+regs > 32)
-        return UnpredictableInstruction();
-
-    // VSTM<mode>.F32 <Rn>{!}, <list of single registers>
-    if (ConditionPassed(cond)) {
-        auto address = u ? ir.GetRegister(n) : IR::U32(ir.Sub(ir.GetRegister(n), ir.Imm32(imm32)));
-        if (w)
-            ir.SetRegister(n, u ? IR::U32(ir.Add(address, ir.Imm32(imm32))) : address);
-        for (size_t i = 0; i < regs; i++) {
-            auto word = ir.GetExtendedRegister(d + i);
-            ir.WriteMemory32(address, word);
-            address = ir.Add(address, ir.Imm32(4));
-        }
     }
+
+    if (p && !w) {
+        ASSERT_MSG(false, "Decode error");
+    }
+
+    if (p == u && w) {
+        return arm_UDF();
+    }
+
+    if (n == Reg::PC && w) {
+        return UnpredictableInstruction();
+    }
+
+    const auto d = ToExtReg(false, Vd, D);
+    const size_t regs = imm8;
+
+    if (regs == 0 || A32::RegNumber(d)+regs > 32) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const u32 imm32 = imm8 << 2;
+    auto address = u ? ir.GetRegister(n) : IR::U32(ir.Sub(ir.GetRegister(n), ir.Imm32(imm32)));
+    if (w) {
+        ir.SetRegister(n, u ? IR::U32(ir.Add(address, ir.Imm32(imm32))) : address);
+    }
+    for (size_t i = 0; i < regs; i++) {
+        const auto word = ir.GetExtendedRegister(d + i);
+        ir.WriteMemory32(address, word);
+        address = ir.Add(address, ir.Imm32(4));
+    }
+
     return true;
 }
 
+// VLDM{mode}<c> <Rn>{!}, <list of double registers>
 bool ArmTranslatorVisitor::vfp2_VLDM_a1(Cond cond, bool p, bool u, bool D, bool w, Reg n, size_t Vd, Imm8 imm8) {
-    if (!p && !u && !w)
+    if (!p && !u && !w) {
         ASSERT_MSG(false, "Decode error");
-    if (p && !w)
-        ASSERT_MSG(false, "Decode error");
-    if (p == u && w)
-        return arm_UDF();
-    if (n == Reg::PC && w)
-        return UnpredictableInstruction();
-
-    ExtReg d = ToExtReg(true, Vd, D);
-    u32 imm32 = imm8 << 2;
-    size_t regs = imm8 / 2;
-
-    if (regs == 0 || regs > 16 || A32::RegNumber(d)+regs > 32)
-        return UnpredictableInstruction();
-
-    // VLDM<mode>.F64 <Rn>{!}, <list of double registers>
-    if (ConditionPassed(cond)) {
-        auto address = u ? ir.GetRegister(n) : IR::U32(ir.Sub(ir.GetRegister(n), ir.Imm32(imm32)));
-        if (w)
-            ir.SetRegister(n, u ? IR::U32(ir.Add(address, ir.Imm32(imm32))) : address);
-        for (size_t i = 0; i < regs; i++) {
-            auto word1 = ir.ReadMemory32(address);
-            address = ir.Add(address, ir.Imm32(4));
-            auto word2 = ir.ReadMemory32(address);
-            address = ir.Add(address, ir.Imm32(4));
-            if (ir.current_location.EFlag()) std::swap(word1, word2);
-            ir.SetExtendedRegister(d + i, ir.Pack2x32To1x64(word1, word2));
-        }
     }
+
+    if (p && !w) {
+        ASSERT_MSG(false, "Decode error");
+    }
+
+    if (p == u && w) {
+        return arm_UDF();
+    }
+
+    if (n == Reg::PC && w) {
+        return UnpredictableInstruction();
+    }
+
+    const auto d = ToExtReg(true, Vd, D);
+    const size_t regs = imm8 / 2;
+
+    if (regs == 0 || regs > 16 || A32::RegNumber(d)+regs > 32) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const u32 imm32 = imm8 << 2;
+    auto address = u ? ir.GetRegister(n) : IR::U32(ir.Sub(ir.GetRegister(n), ir.Imm32(imm32)));
+    if (w) {
+        ir.SetRegister(n, u ? IR::U32(ir.Add(address, ir.Imm32(imm32))) : address);
+    }
+    for (size_t i = 0; i < regs; i++) {
+        auto word1 = ir.ReadMemory32(address);
+        address = ir.Add(address, ir.Imm32(4));
+        auto word2 = ir.ReadMemory32(address);
+        address = ir.Add(address, ir.Imm32(4));
+
+        if (ir.current_location.EFlag()) {
+            std::swap(word1, word2);
+        }
+
+        ir.SetExtendedRegister(d + i, ir.Pack2x32To1x64(word1, word2));
+    }
+
     return true;
 }
 
+// VLDM{mode}<c> <Rn>{!}, <list of single registers>
 bool ArmTranslatorVisitor::vfp2_VLDM_a2(Cond cond, bool p, bool u, bool D, bool w, Reg n, size_t Vd, Imm8 imm8) {
-    if (!p && !u && !w)
+    if (!p && !u && !w) {
         ASSERT_MSG(false, "Decode error");
-    if (p && !w)
-        ASSERT_MSG(false, "Decode error");
-    if (p == u && w)
-        return arm_UDF();
-    if (n == Reg::PC && w)
-        return UnpredictableInstruction();
-
-    ExtReg d = ToExtReg(false, Vd, D);
-    u32 imm32 = imm8 << 2;
-    size_t regs = imm8;
-
-    if (regs == 0 || A32::RegNumber(d)+regs > 32)
-        return UnpredictableInstruction();
-
-    // VLDM<mode>.F32 <Rn>{!}, <list of single registers>
-    if (ConditionPassed(cond)) {
-        auto address = u ? ir.GetRegister(n) : IR::U32(ir.Sub(ir.GetRegister(n), ir.Imm32(imm32)));
-        if (w)
-            ir.SetRegister(n, u ? IR::U32(ir.Add(address, ir.Imm32(imm32))) : address);
-        for (size_t i = 0; i < regs; i++) {
-            auto word = ir.ReadMemory32(address);
-            address = ir.Add(address, ir.Imm32(4));
-            ir.SetExtendedRegister(d + i, word);
-        }
     }
+
+    if (p && !w) {
+        ASSERT_MSG(false, "Decode error");
+    }
+
+    if (p == u && w) {
+        return arm_UDF();
+    }
+
+    if (n == Reg::PC && w) {
+        return UnpredictableInstruction();
+    }
+
+    const auto d = ToExtReg(false, Vd, D);
+    const size_t regs = imm8;
+
+    if (regs == 0 || A32::RegNumber(d)+regs > 32) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const u32 imm32 = imm8 << 2;
+    auto address = u ? ir.GetRegister(n) : IR::U32(ir.Sub(ir.GetRegister(n), ir.Imm32(imm32)));
+    if (w) {
+        ir.SetRegister(n, u ? IR::U32(ir.Add(address, ir.Imm32(imm32))) : address);
+    }
+    for (size_t i = 0; i < regs; i++) {
+        const auto word = ir.ReadMemory32(address);
+        address = ir.Add(address, ir.Imm32(4));
+        ir.SetExtendedRegister(d + i, word);
+    }
+
     return true;
 }
 


### PR DESCRIPTION
Mainly just inverts conditionals related to:

```cpp
if (ConditionPassed) {
    <lots of code>
}
```

to unindent stuff and make it similar to how the A64 side of things lays out everything. I've kept everything separate to make it nicer to review, though most of it is just the same thing across several files. I can also squash this down to a single commit if it's preferable for merging that way.