### PR TITLE
tests/a32/testenv: Make A32TestEnv's code_mem member a std::vector

### DIFF
--- a/tests/A32/fuzz_arm.cpp
+++ b/tests/A32/fuzz_arm.cpp
@@ -108,7 +108,8 @@ void FuzzJitArm(const size_t instruction_count, const size_t instructions_to_exe
     ArmTestEnv test_env;
 
     // Prepare memory
-    test_env.code_mem.fill(0xEAFFFFFE); // b +#0
+    test_env.code_mem.resize(instruction_count + 1);
+    test_env.code_mem.back() = 0xEAFFFFFE; // b +#0
 
     // Prepare test subjects
     ARMul_State interp{USER32MODE};
@@ -251,13 +252,14 @@ TEST_CASE( "arm: Optimization Failure (Randomized test case)", "[arm][A32]" ) {
 
     ArmTestEnv test_env;
     Dynarmic::A32::Jit jit{GetUserConfig(&test_env)};
-    test_env.code_mem.fill({});
-    test_env.code_mem[0] = 0xe35f0cd9; // cmp pc, #55552
-    test_env.code_mem[1] = 0xe11c0474; // tst r12, r4, ror r4
-    test_env.code_mem[2] = 0xe1a006a7; // mov r0, r7, lsr #13
-    test_env.code_mem[3] = 0xe35107fa; // cmp r1, #0x3E80000
-    test_env.code_mem[4] = 0xe2a54c8a; // adc r4, r5, #35328
-    test_env.code_mem[5] = 0xeafffffe; // b +#0
+    test_env.code_mem = {
+        0xe35f0cd9, // cmp pc, #55552
+        0xe11c0474, // tst r12, r4, ror r4
+        0xe1a006a7, // mov r0, r7, lsr #13
+        0xe35107fa, // cmp r1, #0x3E80000
+        0xe2a54c8a, // adc r4, r5, #35328
+        0xeafffffe, // b +#0
+    };
 
     jit.Regs() = {
             0x6973b6bb, 0x267ea626, 0x69debf49, 0x8f976895, 0x4ecd2d0d, 0xcf89b8c7, 0xb6713f85, 0x15e2aa5,
@@ -295,9 +297,10 @@ TEST_CASE( "arm: shsax r11, sp, r9 (Edge-case)", "[arm][A32]" ) {
 
     ArmTestEnv test_env;
     Dynarmic::A32::Jit jit{GetUserConfig(&test_env)};
-    test_env.code_mem.fill({});
-    test_env.code_mem[0] = 0xe63dbf59; // shsax r11, sp, r9
-    test_env.code_mem[1] = 0xeafffffe; // b +#0
+    test_env.code_mem = {
+        0xe63dbf59, // shsax r11, sp, r9
+        0xeafffffe, // b +#0
+    };
 
     jit.Regs() = {
             0x3a3b8b18, 0x96156555, 0xffef039f, 0xafb946f2, 0x2030a69a, 0xafe09b2a, 0x896823c8, 0xabde0ded,
@@ -334,9 +337,10 @@ TEST_CASE( "arm: uasx (Edge-case)", "[arm][A32]" ) {
 
     ArmTestEnv test_env;
     Dynarmic::A32::Jit jit{GetUserConfig(&test_env)};
-    test_env.code_mem.fill({});
-    test_env.code_mem[0] = 0xe6549f35; // uasx r9, r4, r5
-    test_env.code_mem[1] = 0xeafffffe; // b +#0
+    test_env.code_mem = {
+        0xe6549f35, // uasx r9, r4, r5
+        0xeafffffe, // b +#0
+    };
 
     jit.Regs()[4] = 0x8ed38f4c;
     jit.Regs()[5] = 0x0000261d;
@@ -364,9 +368,10 @@ struct VfpTest {
 static void RunVfpTests(u32 instr, std::vector<VfpTest> tests) {
     ArmTestEnv test_env;
     Dynarmic::A32::Jit jit{GetUserConfig(&test_env)};
-    test_env.code_mem.fill({});
-    test_env.code_mem[0] = instr;
-    test_env.code_mem[1] = 0xeafffffe; // b +#0
+    test_env.code_mem = {
+        instr,
+        0xeafffffe, // b +#0
+    };
 
     printf("vfp test 0x%08x\r", instr);
 
@@ -993,11 +998,12 @@ TEST_CASE("Fuzz ARM sum of absolute differences", "[JitX64][A32]") {
     }
 }
 
-TEST_CASE( "SMUAD", "[JitX64][A32]" ) {
+TEST_CASE("SMUAD", "[JitX64][A32]") {
     ArmTestEnv test_env;
     Dynarmic::A32::Jit jit{GetUserConfig(&test_env)};
-    test_env.code_mem.fill({});
-    test_env.code_mem[0] = 0xE700F211; // smuad r0, r1, r2
+    test_env.code_mem = {
+        0xE700F211 // smuad r0, r1, r2
+    };
 
     jit.Regs() = {
             0, // Rd
@@ -1154,11 +1160,12 @@ TEST_CASE("Fuzz ARM packing instructions", "[JitX64][A32]") {
 TEST_CASE("arm: Test InvalidateCacheRange", "[arm][A32]") {
     ArmTestEnv test_env;
     Dynarmic::A32::Jit jit{GetUserConfig(&test_env)};
-    test_env.code_mem.fill({});
-    test_env.code_mem[0] = 0xe3a00005; // mov r0, #5
-    test_env.code_mem[1] = 0xe3a0100D; // mov r1, #13
-    test_env.code_mem[2] = 0xe0812000; // add r2, r1, r0
-    test_env.code_mem[3] = 0xeafffffe; // b +#0 (infinite loop)
+    test_env.code_mem = {
+        0xe3a00005, // mov r0, #5
+        0xe3a0100D, // mov r1, #13
+        0xe0812000, // add r2, r1, r0
+        0xeafffffe, // b +#0 (infinite loop)
+    };
 
     jit.Regs() = {};
     jit.SetCpsr(0x000001d0); // User-mode

--- a/tests/A32/fuzz_thumb.cpp
+++ b/tests/A32/fuzz_thumb.cpp
@@ -176,7 +176,8 @@ void FuzzJitThumb(const size_t instruction_count, const size_t instructions_to_e
     ThumbTestEnv test_env;
 
     // Prepare memory
-    test_env.code_mem.fill(0xE7FE); // b +#0
+    test_env.code_mem.resize(instruction_count + 1);
+    test_env.code_mem.back() = 0xE7FE; // b +#0
 
     // Prepare test subjects
     ARMul_State interp{USER32MODE};
@@ -278,9 +279,6 @@ TEST_CASE("Fuzz Thumb instructions set 2 (affects PC)", "[JitX64][Thumb]") {
 TEST_CASE("Verify fix for off by one error in MemoryRead32 worked", "[Thumb]") {
     ThumbTestEnv test_env;
 
-    // Prepare memory
-    test_env.code_mem.fill(0xE7FE); // b +#0
-
     // Prepare test subjects
     ARMul_State interp{USER32MODE};
     interp.user_callbacks = &test_env;
@@ -305,11 +303,14 @@ TEST_CASE("Verify fix for off by one error in MemoryRead32 worked", "[Thumb]") {
         0x00000000,
     };
 
-    test_env.code_mem[0] = 0x40B8; // lsls r0, r7, #0
-    test_env.code_mem[1] = 0x01CA; // lsls r2, r1, #7
-    test_env.code_mem[2] = 0x83A1; // strh r1, [r4, #28]
-    test_env.code_mem[3] = 0x708A; // strb r2, [r1, #2]
-    test_env.code_mem[4] = 0xBCC4; // pop {r2, r6, r7}
+    test_env.code_mem = {
+        0x40B8, // lsls r0, r7, #0
+        0x01CA, // lsls r2, r1, #7
+        0x83A1, // strh r1, [r4, #28]
+        0x708A, // strb r2, [r1, #2]
+        0xBCC4, // pop {r2, r6, r7}
+        0xE7FE, // b +#0
+    };
 
     RunInstance(1, test_env, interp, jit, initial_regs, 5, 5);
 }

--- a/tests/A32/test_thumb_instructions.cpp
+++ b/tests/A32/test_thumb_instructions.cpp
@@ -19,12 +19,13 @@ static Dynarmic::A32::UserConfig GetUserConfig(ThumbTestEnv* testenv) {
     return user_config;
 }
 
-TEST_CASE( "thumb: lsls r0, r1, #2", "[thumb]" ) {
+TEST_CASE("thumb: lsls r0, r1, #2", "[thumb]") {
     ThumbTestEnv test_env;
     Dynarmic::A32::Jit jit{GetUserConfig(&test_env)};
-    test_env.code_mem.fill({});
-    test_env.code_mem[0] = 0x0088; // lsls r0, r1, #2
-    test_env.code_mem[1] = 0xE7FE; // b +#0
+    test_env.code_mem = {
+        0x0088, // lsls r0, r1, #2
+        0xE7FE, // b +#0
+    };
 
     jit.Regs()[0] = 1;
     jit.Regs()[1] = 2;
@@ -40,12 +41,13 @@ TEST_CASE( "thumb: lsls r0, r1, #2", "[thumb]" ) {
     REQUIRE(jit.Cpsr() == 0x00000030);
 }
 
-TEST_CASE( "thumb: lsls r0, r1, #31", "[thumb]" ) {
+TEST_CASE("thumb: lsls r0, r1, #31", "[thumb]") {
     ThumbTestEnv test_env;
     Dynarmic::A32::Jit jit{GetUserConfig(&test_env)};
-    test_env.code_mem.fill({});
-    test_env.code_mem[0] = 0x07C8; // lsls r0, r1, #31
-    test_env.code_mem[1] = 0xE7FE; // b +#0
+    test_env.code_mem = {
+        0x07C8, // lsls r0, r1, #31
+        0xE7FE, // b +#0
+    };
 
     jit.Regs()[0] = 1;
     jit.Regs()[1] = 0xFFFFFFFF;
@@ -61,12 +63,13 @@ TEST_CASE( "thumb: lsls r0, r1, #31", "[thumb]" ) {
     REQUIRE(jit.Cpsr() == 0xA0000030); // N, C flags, Thumb, User-mode
 }
 
-TEST_CASE( "thumb: revsh r4, r3", "[thumb]" ) {
+TEST_CASE("thumb: revsh r4, r3", "[thumb]") {
     ThumbTestEnv test_env;
     Dynarmic::A32::Jit jit{GetUserConfig(&test_env)};
-    test_env.code_mem.fill({});
-    test_env.code_mem[0] = 0xBADC; // revsh r4, r3
-    test_env.code_mem[1] = 0xE7FE; // b +#0
+    test_env.code_mem = {
+        0xBADC, // revsh r4, r3
+        0xE7FE, // b +#0
+    };
 
     jit.Regs()[3] = 0x12345678;
     jit.Regs()[15] = 0; // PC = 0
@@ -81,12 +84,13 @@ TEST_CASE( "thumb: revsh r4, r3", "[thumb]" ) {
     REQUIRE(jit.Cpsr() == 0x00000030); // Thumb, User-mode
 }
 
-TEST_CASE( "thumb: ldr r3, [r3, #28]", "[thumb]" ) {
+TEST_CASE("thumb: ldr r3, [r3, #28]", "[thumb]") {
     ThumbTestEnv test_env;
     Dynarmic::A32::Jit jit{GetUserConfig(&test_env)};
-    test_env.code_mem.fill({});
-    test_env.code_mem[0] = 0x69DB; // ldr r3, [r3, #28]
-    test_env.code_mem[1] = 0xE7FE; // b +#0
+    test_env.code_mem = {
+        0x69DB, // ldr r3, [r3, #28]
+        0xE7FE, // b +#0
+    };
 
     jit.Regs()[3] = 0x12345678;
     jit.Regs()[15] = 0; // PC = 0
@@ -100,12 +104,13 @@ TEST_CASE( "thumb: ldr r3, [r3, #28]", "[thumb]" ) {
     REQUIRE(jit.Cpsr() == 0x00000030); // Thumb, User-mode
 }
 
-TEST_CASE( "thumb: blx +#67712", "[thumb]" ) {
+TEST_CASE("thumb: blx +#67712", "[thumb]") {
     ThumbTestEnv test_env;
     Dynarmic::A32::Jit jit{GetUserConfig(&test_env)};
-    test_env.code_mem.fill({});
-    test_env.code_mem[0] = 0xF010; test_env.code_mem[1] = 0xEC3E; // blx +#67712
-    test_env.code_mem[2] = 0xE7FE; // b +#0
+    test_env.code_mem = {
+        0xF010, 0xEC3E, // blx +#67712
+        0xE7FE          // b +#0
+    };
 
     jit.Regs()[15] = 0; // PC = 0
     jit.SetCpsr(0x00000030); // Thumb, User-mode
@@ -118,12 +123,13 @@ TEST_CASE( "thumb: blx +#67712", "[thumb]" ) {
     REQUIRE(jit.Cpsr() == 0x00000010); // User-mode
 }
 
-TEST_CASE( "thumb: bl +#234584", "[thumb]" ) {
+TEST_CASE("thumb: bl +#234584", "[thumb]") {
     ThumbTestEnv test_env;
     Dynarmic::A32::Jit jit{GetUserConfig(&test_env)};
-    test_env.code_mem.fill({});
-    test_env.code_mem[0] = 0xF039; test_env.code_mem[1] = 0xFA2A; // bl +#234584
-    test_env.code_mem[2] = 0xE7FE; // b +#0
+    test_env.code_mem = {
+        0xF039, 0xFA2A, // bl +#234584
+        0xE7FE          // b +#0
+    };
 
     jit.Regs()[15] = 0; // PC = 0
     jit.SetCpsr(0x00000030); // Thumb, User-mode
@@ -136,12 +142,13 @@ TEST_CASE( "thumb: bl +#234584", "[thumb]" ) {
     REQUIRE(jit.Cpsr() == 0x00000030); // Thumb, User-mode
 }
 
-TEST_CASE( "thumb: bl -#42", "[thumb]" ) {
+TEST_CASE("thumb: bl -#42", "[thumb]") {
     ThumbTestEnv test_env;
     Dynarmic::A32::Jit jit{GetUserConfig(&test_env)};
-    test_env.code_mem.fill({});
-    test_env.code_mem[0] = 0xF7FF; test_env.code_mem[1] = 0xFFE9; // bl -#42
-    test_env.code_mem[2] = 0xE7FE; // b +#0
+    test_env.code_mem = {
+        0xF7FF, 0xFFE9, // bl -#42
+        0xE7FE          // b +#0
+    };
 
     jit.Regs()[15] = 0; // PC = 0
     jit.SetCpsr(0x00000030); // Thumb, User-mode

--- a/tests/A32/testenv.h
+++ b/tests/A32/testenv.h
@@ -25,7 +25,7 @@ public:
 
     u64 ticks_left = 0;
     bool code_mem_modified_by_guest = false;
-    std::array<InstructionType, 2048> code_mem{};
+    std::vector<InstructionType> code_mem;
     std::map<u32, u8> modified_memory;
     std::vector<std::string> interrupts;
 


### PR DESCRIPTION
Makes the data member consistent with the A64 test environment.