### PR TITLE
A64: Fall back to interpreting for FCADD and FCMLA half-precision variants

### DIFF
--- a/src/frontend/A64/translate/impl/simd_three_same_extra.cpp
+++ b/src/frontend/A64/translate/impl/simd_three_same_extra.cpp
@@ -66,7 +66,7 @@ bool TranslatorVisitor::FCMLA_vec(bool Q, Imm<2> size, Vec Vm, Imm<2> rot, Vec V
 
     // TODO: Currently we don't support half-precision floating point
     if (esize == 16) {
-        return UnallocatedEncoding();
+        return InterpretThisInstruction();
     }
 
     const size_t datasize = Q ? 128 : 64;
@@ -139,7 +139,7 @@ bool TranslatorVisitor::FCADD_vec(bool Q, Imm<2> size, Vec Vm, Imm<1> rot, Vec V
 
     // TODO: Currently we don't support half-precision floating point
     if (esize == 16) {
-        return UnallocatedEncoding();
+        return InterpretThisInstruction();
     }
 
     const size_t datasize = Q ? 128 : 64;


### PR DESCRIPTION
An overly strong enforcement that I mistakenly introduced in #439. Rather than straight-up treating them as undefined, we can fall back to an interpreter in this case in the meantime until we support half-precision floating point.