### PR TITLE
common/fp/unpacked: Add FPRoundCV and FPUnpackCV

### DIFF
--- a/src/common/fp/op/FPConvert.cpp
+++ b/src/common/fp/op/FPConvert.cpp
@@ -59,7 +59,7 @@ FPT_TO FPConvertNaN(FPT_FROM op) {
 
 template <typename FPT_TO, typename FPT_FROM>
 FPT_TO FPConvert(FPT_FROM op, FPCR fpcr, RoundingMode rounding_mode, FPSR& fpsr) {
-    const auto [type, sign, value] = FPUnpack<FPT_FROM>(op, fpcr, fpsr);
+    const auto [type, sign, value] = FPUnpackCV<FPT_FROM>(op, fpcr, fpsr);
     const bool is_althp = Common::BitSize<FPT_TO>() == 16 && fpcr.AHP();
 
     if (type == FPType::SNaN || type == FPType::QNaN) {

--- a/src/common/fp/op/FPConvert.cpp
+++ b/src/common/fp/op/FPConvert.cpp
@@ -93,7 +93,7 @@ FPT_TO FPConvert(FPT_FROM op, FPCR fpcr, RoundingMode rounding_mode, FPSR& fpsr)
         return FPInfo<FPT_TO>::Zero(sign);
     }
 
-    return FPRoundBase<FPT_TO>(value, fpcr, rounding_mode, fpsr);
+    return FPRoundCV<FPT_TO>(value, fpcr, rounding_mode, fpsr);
 }
 
 template u64 FPConvert<u64, u32>(u32 op, FPCR fpcr, RoundingMode rounding_mode, FPSR& fpsr);

--- a/src/common/fp/unpacked.h
+++ b/src/common/fp/unpacked.h
@@ -70,6 +70,12 @@ FPT FPRound(FPUnpacked op, FPCR fpcr, RoundingMode rounding, FPSR& fpsr) {
 }
 
 template<typename FPT>
+FPT FPRoundCV(FPUnpacked op, FPCR fpcr, RoundingMode rounding, FPSR& fpsr) {
+    fpcr.FZ16(false);
+    return FPRoundBase<FPT>(op, fpcr, rounding, fpsr);
+}
+
+template<typename FPT>
 FPT FPRound(FPUnpacked op, FPCR fpcr, FPSR& fpsr) {
     return FPRound<FPT>(op, fpcr, fpcr.RMode(), fpsr);
 }

--- a/src/common/fp/unpacked.h
+++ b/src/common/fp/unpacked.h
@@ -55,6 +55,12 @@ template<typename FPT>
 std::tuple<FPType, bool, FPUnpacked> FPUnpack(FPT op, FPCR fpcr, FPSR& fpsr);
 
 template<typename FPT>
+std::tuple<FPType, bool, FPUnpacked> FPUnpackCV(FPT op, FPCR fpcr, FPSR& fpsr) {
+    fpcr.FZ16(false);
+    return FPUnpack(op, fpcr, fpsr);
+}
+
+template<typename FPT>
 FPT FPRoundBase(FPUnpacked op, FPCR fpcr, RoundingMode rounding, FPSR& fpsr);
 
 template<typename FPT>


### PR DESCRIPTION
These match the equivalent pseudocode within the ARMv8 reference manual, which will be necessary for half-precision floating-point support.

This also makes use of them within FPConvert.