### PR TITLE
common/fp: Minor adjustments for half-precision floating point support

### DIFF
--- a/src/common/fp/process_nan.cpp
+++ b/src/common/fp/process_nan.cpp
@@ -31,12 +31,13 @@ FPT FPProcessNaN(FPType type, FPT op, FPCR fpcr, FPSR& fpsr) {
     }
 
     if (fpcr.DN()) {
-        result = FPInfo<FPT>::DefaultNaN();
+        result = FPT(FPInfo<FPT>::DefaultNaN());
     }
 
     return result;
 }
 
+template u16 FPProcessNaN<u16>(FPType type, u16 op, FPCR fpcr, FPSR& fpsr);
 template u32 FPProcessNaN<u32>(FPType type, u32 op, FPCR fpcr, FPSR& fpsr);
 template u64 FPProcessNaN<u64>(FPType type, u64 op, FPCR fpcr, FPSR& fpsr);
 
@@ -57,6 +58,7 @@ std::optional<FPT> FPProcessNaNs(FPType type1, FPType type2, FPT op1, FPT op2, F
     return std::nullopt;
 }
 
+template std::optional<u16> FPProcessNaNs<u16>(FPType type1, FPType type2, u16 op1, u16 op2, FPCR fpcr, FPSR& fpsr);
 template std::optional<u32> FPProcessNaNs<u32>(FPType type1, FPType type2, u32 op1, u32 op2, FPCR fpcr, FPSR& fpsr);
 template std::optional<u64> FPProcessNaNs<u64>(FPType type1, FPType type2, u64 op1, u64 op2, FPCR fpcr, FPSR& fpsr);
 
@@ -83,6 +85,7 @@ std::optional<FPT> FPProcessNaNs3(FPType type1, FPType type2, FPType type3, FPT 
     return std::nullopt;
 }
 
+template std::optional<u16> FPProcessNaNs3<u16>(FPType type1, FPType type2, FPType type3, u16 op1, u16 op2, u16 op3, FPCR fpcr, FPSR& fpsr);
 template std::optional<u32> FPProcessNaNs3<u32>(FPType type1, FPType type2, FPType type3, u32 op1, u32 op2, u32 op3, FPCR fpcr, FPSR& fpsr);
 template std::optional<u64> FPProcessNaNs3<u64>(FPType type1, FPType type2, FPType type3, u64 op1, u64 op2, u64 op3, FPCR fpcr, FPSR& fpsr);
 

--- a/src/common/fp/unpacked.cpp
+++ b/src/common/fp/unpacked.cpp
@@ -88,7 +88,7 @@ FPT FPRoundBase(FPUnpacked op, FPCR fpcr, RoundingMode rounding, FPSR& fpsr) {
 
     if (((!isFP16 && fpcr.FZ()) || (isFP16 && fpcr.FZ16())) && exponent < minimum_exp) {
         fpsr.UFC(true);
-        return FPInfo<FPT>::Zero(sign);
+        return FPT(FPInfo<FPT>::Zero(sign));
     }
 
     int biased_exp = std::max<int>(exponent - minimum_exp + 1, 0);
@@ -151,13 +151,13 @@ FPT FPRoundBase(FPUnpacked op, FPCR fpcr, RoundingMode rounding, FPSR& fpsr) {
 #endif
         constexpr int max_biased_exp = (1 << E) - 1;
         if (biased_exp >= max_biased_exp) {
-            result = overflow_to_inf ? FPInfo<FPT>::Infinity(sign) : FPInfo<FPT>::MaxNormal(sign);
+            result = overflow_to_inf ? FPT(FPInfo<FPT>::Infinity(sign)) : FPT(FPInfo<FPT>::MaxNormal(sign));
             FPProcessException(FPExc::Overflow, fpcr, fpsr);
             FPProcessException(FPExc::Inexact, fpcr, fpsr);
         } else {
             result = sign ? 1 : 0;
             result <<= E;
-            result += biased_exp;
+            result += FPT(biased_exp);
             result <<= F;
             result |= static_cast<FPT>(mantissa) & FPInfo<FPT>::mantissa_mask;
             if (error != ResidualError::Zero) {
@@ -172,7 +172,7 @@ FPT FPRoundBase(FPUnpacked op, FPCR fpcr, RoundingMode rounding, FPSR& fpsr) {
         } else {
             result = sign ? 1 : 0;
             result <<= E;
-            result += biased_exp;
+            result += FPT(biased_exp);
             result <<= F;
             result |= static_cast<FPT>(mantissa) & FPInfo<FPT>::mantissa_mask;
             if (error != ResidualError::Zero) {
@@ -183,6 +183,7 @@ FPT FPRoundBase(FPUnpacked op, FPCR fpcr, RoundingMode rounding, FPSR& fpsr) {
     return result;
 }
 
+template u16 FPRoundBase<u16>(FPUnpacked op, FPCR fpcr, RoundingMode rounding, FPSR& fpsr);
 template u32 FPRoundBase<u32>(FPUnpacked op, FPCR fpcr, RoundingMode rounding, FPSR& fpsr);
 template u64 FPRoundBase<u64>(FPUnpacked op, FPCR fpcr, RoundingMode rounding, FPSR& fpsr);
 

--- a/src/common/fp/unpacked.cpp
+++ b/src/common/fp/unpacked.cpp
@@ -15,7 +15,7 @@
 namespace Dynarmic::FP {
 
 template<typename FPT>
-std::tuple<FPType, bool, FPUnpacked> FPUnpack(FPT op, FPCR fpcr, FPSR& fpsr) {
+std::tuple<FPType, bool, FPUnpacked> FPUnpackBase(FPT op, FPCR fpcr, FPSR& fpsr) {
     constexpr size_t sign_bit = FPInfo<FPT>::exponent_width + FPInfo<FPT>::explicit_mantissa_width;
     constexpr size_t exponent_high_bit = FPInfo<FPT>::exponent_width + FPInfo<FPT>::explicit_mantissa_width - 1;
     constexpr size_t exponent_low_bit = FPInfo<FPT>::explicit_mantissa_width;
@@ -52,8 +52,8 @@ std::tuple<FPType, bool, FPUnpacked> FPUnpack(FPT op, FPCR fpcr, FPSR& fpsr) {
     return {FPType::Nonzero, sign, {sign, exp, frac}};
 }
 
-template std::tuple<FPType, bool, FPUnpacked> FPUnpack<u32>(u32 op, FPCR fpcr, FPSR& fpsr);
-template std::tuple<FPType, bool, FPUnpacked> FPUnpack<u64>(u64 op, FPCR fpcr, FPSR& fpsr);
+template std::tuple<FPType, bool, FPUnpacked> FPUnpackBase<u32>(u32 op, FPCR fpcr, FPSR& fpsr);
+template std::tuple<FPType, bool, FPUnpacked> FPUnpackBase<u64>(u64 op, FPCR fpcr, FPSR& fpsr);
 
 template<size_t F>
 std::tuple<bool, int, u64, ResidualError> Normalize(FPUnpacked op, int extra_right_shift = 0) {

--- a/src/common/fp/unpacked.h
+++ b/src/common/fp/unpacked.h
@@ -52,7 +52,13 @@ constexpr FPUnpacked ToNormalized(bool sign, int exponent, u64 value) {
 }
 
 template<typename FPT>
-std::tuple<FPType, bool, FPUnpacked> FPUnpack(FPT op, FPCR fpcr, FPSR& fpsr);
+std::tuple<FPType, bool, FPUnpacked> FPUnpackBase(FPT op, FPCR fpcr, FPSR& fpsr);
+
+template<typename FPT>
+std::tuple<FPType, bool, FPUnpacked> FPUnpack(FPT op, FPCR fpcr, FPSR& fpsr) {
+    fpcr.AHP(false);
+    return FPUnpackBase(op, fpcr, fpsr);
+}
 
 template<typename FPT>
 std::tuple<FPType, bool, FPUnpacked> FPUnpackCV(FPT op, FPCR fpcr, FPSR& fpsr) {


### PR DESCRIPTION
Adds u16 instantiations for the core functions required by other functions. This is necessary to further support half-precision floating point.