### PR TITLE
backend/x64: Allow fsizes of 16 in ChooseOnFsize

### DIFF
--- a/src/backend/x64/emit_x64_floating_point.cpp
+++ b/src/backend/x64/emit_x64_floating_point.cpp
@@ -58,12 +58,16 @@ constexpr u64 f64_max_u64_lim = 0x43f0000000000000u; // 2^64 as a double (actual
 
 template<size_t fsize, typename T>
 T ChooseOnFsize([[maybe_unused]] T f32, [[maybe_unused]] T f64) {
-    static_assert(fsize == 32 || fsize == 64, "fsize must be either 32 or 64");
+    static_assert(fsize == 16 || fsize == 32 || fsize == 64,
+                  "fsize must be 16, 32, or 64");
 
     if constexpr (fsize == 32) {
         return f32;
-    } else {
+    } else if constexpr (fsize == 64){
         return f64;
+    } else {
+        // x64 has no half-precision instructions yet.
+        UNREACHABLE();
     }
 }
 

--- a/src/backend/x64/emit_x64_vector_floating_point.cpp
+++ b/src/backend/x64/emit_x64_vector_floating_point.cpp
@@ -39,12 +39,16 @@ namespace {
 
 template<size_t fsize, typename T>
 T ChooseOnFsize([[maybe_unused]] T f32, [[maybe_unused]] T f64) {
-    static_assert(fsize == 32 || fsize == 64, "fsize must be either 32 or 64");
+    static_assert(fsize == 16 || fsize == 32 || fsize == 64,
+                  "fsize must be either 16, 32, or 64");
 
     if constexpr (fsize == 32) {
         return f32;
-    } else {
+    } else if constexpr (fsize == 64) {
         return f64;
+    } else {
+        // x64 has no half-precision instructions yet.
+        UNREACHABLE();
     }
 }
 


### PR DESCRIPTION
Given half-precision instructions aren't present on x64, we can allow the size, but assert on it, given all half-precision instructions are going to have to fall back to softfloat implementations.

This allows functions that have a fast path (that uses ChooseOnFsize), and a softfloat fallback to be easily usable with half-precision floating point overloads.