### PR TITLE
A64: Implement SQRDMULH and SQDMULL's scalar indexed variants

### DIFF
--- a/src/frontend/A64/decoder/a64.inc
+++ b/src/frontend/A64/decoder/a64.inc
@@ -535,9 +535,9 @@ INST(FCVTZU_fix_1,           "FCVTZU (vector, fixed-point)",              "01111
 // Data Processing - FP and SIMD - SIMD Scalar x indexed element
 //INST(SQDMLAL_elt_1,          "SQDMLAL, SQDMLAL2 (by element)",            "01011111zzLMmmmm0011H0nnnnnddddd")
 //INST(SQDMLSL_elt_1,          "SQDMLSL, SQDMLSL2 (by element)",            "01011111zzLMmmmm0111H0nnnnnddddd")
-//INST(SQDMULL_elt_1,          "SQDMULL, SQDMULL2 (by element)",            "01011111zzLMmmmm1011H0nnnnnddddd")
+INST(SQDMULL_elt_1,          "SQDMULL, SQDMULL2 (by element)",            "01011111zzLMmmmm1011H0nnnnnddddd")
 INST(SQDMULH_elt_1,          "SQDMULH (by element)",                      "01011111zzLMmmmm1100H0nnnnnddddd")
-INST(SQRDMULH_elt_1,         "SQRDMULH (by element)",                     "01011111zzLMmmmm1101H0nnnnnddddd")
+//INST(SQRDMULH_elt_1,         "SQRDMULH (by element)",                     "01011111zzLMmmmm1101H0nnnnnddddd")
 //INST(FMLA_elt_1,             "FMLA (by element)",                         "0101111100LMmmmm0001H0nnnnnddddd")
 INST(FMLA_elt_2,             "FMLA (by element)",                         "010111111zLMmmmm0001H0nnnnnddddd")
 //INST(FMLS_elt_1,             "FMLS (by element)",                         "0101111100LMmmmm0101H0nnnnnddddd")

--- a/src/frontend/A64/decoder/a64.inc
+++ b/src/frontend/A64/decoder/a64.inc
@@ -537,7 +537,7 @@ INST(FCVTZU_fix_1,           "FCVTZU (vector, fixed-point)",              "01111
 //INST(SQDMLSL_elt_1,          "SQDMLSL, SQDMLSL2 (by element)",            "01011111zzLMmmmm0111H0nnnnnddddd")
 INST(SQDMULL_elt_1,          "SQDMULL, SQDMULL2 (by element)",            "01011111zzLMmmmm1011H0nnnnnddddd")
 INST(SQDMULH_elt_1,          "SQDMULH (by element)",                      "01011111zzLMmmmm1100H0nnnnnddddd")
-//INST(SQRDMULH_elt_1,         "SQRDMULH (by element)",                     "01011111zzLMmmmm1101H0nnnnnddddd")
+INST(SQRDMULH_elt_1,         "SQRDMULH (by element)",                     "01011111zzLMmmmm1101H0nnnnnddddd")
 //INST(FMLA_elt_1,             "FMLA (by element)",                         "0101111100LMmmmm0001H0nnnnnddddd")
 INST(FMLA_elt_2,             "FMLA (by element)",                         "010111111zLMmmmm0001H0nnnnnddddd")
 //INST(FMLS_elt_1,             "FMLS (by element)",                         "0101111100LMmmmm0101H0nnnnnddddd")

--- a/src/frontend/A64/decoder/a64.inc
+++ b/src/frontend/A64/decoder/a64.inc
@@ -537,7 +537,7 @@ INST(FCVTZU_fix_1,           "FCVTZU (vector, fixed-point)",              "01111
 //INST(SQDMLSL_elt_1,          "SQDMLSL, SQDMLSL2 (by element)",            "01011111zzLMmmmm0111H0nnnnnddddd")
 //INST(SQDMULL_elt_1,          "SQDMULL, SQDMULL2 (by element)",            "01011111zzLMmmmm1011H0nnnnnddddd")
 INST(SQDMULH_elt_1,          "SQDMULH (by element)",                      "01011111zzLMmmmm1100H0nnnnnddddd")
-//INST(SQRDMULH_elt_1,         "SQRDMULH (by element)",                     "01011111zzLMmmmm1101H0nnnnnddddd")
+INST(SQRDMULH_elt_1,         "SQRDMULH (by element)",                     "01011111zzLMmmmm1101H0nnnnnddddd")
 //INST(FMLA_elt_1,             "FMLA (by element)",                         "0101111100LMmmmm0001H0nnnnnddddd")
 INST(FMLA_elt_2,             "FMLA (by element)",                         "010111111zLMmmmm0001H0nnnnnddddd")
 //INST(FMLS_elt_1,             "FMLS (by element)",                         "0101111100LMmmmm0101H0nnnnnddddd")

--- a/src/frontend/A64/translate/impl/impl.h
+++ b/src/frontend/A64/translate/impl/impl.h
@@ -642,9 +642,9 @@ struct TranslatorVisitor final {
     bool FCVTZU_fix_1(Imm<4> immh, Imm<3> immb, Vec Vn, Vec Vd);
 
     // Data Processing - FP and SIMD - SIMD Scalar x indexed element
-    bool SQDMLAL_elt_1(Imm<2> size, Imm<1> L, Imm<1> M, Imm<4> Vmlo, Imm<1> H, Reg Rn, Vec Vd);
-    bool SQDMLSL_elt_1(Imm<2> size, Imm<1> L, Imm<1> M, Imm<4> Vmlo, Imm<1> H, Reg Rn, Vec Vd);
-    bool SQDMULL_elt_1(Imm<2> size, Imm<1> L, Imm<1> M, Imm<4> Vmlo, Imm<1> H, Reg Rn, Vec Vd);
+    bool SQDMLAL_elt_1(Imm<2> size, Imm<1> L, Imm<1> M, Imm<4> Vmlo, Imm<1> H, Vec Vn, Vec Vd);
+    bool SQDMLSL_elt_1(Imm<2> size, Imm<1> L, Imm<1> M, Imm<4> Vmlo, Imm<1> H, Vec Vn, Vec Vd);
+    bool SQDMULL_elt_1(Imm<2> size, Imm<1> L, Imm<1> M, Imm<4> Vmlo, Imm<1> H, Vec Vn, Vec Vd);
     bool SQDMULH_elt_1(Imm<2> size, Imm<1> L, Imm<1> M, Imm<4> Vmlo, Imm<1> H, Vec Vn, Vec Vd);
     bool SQRDMULH_elt_1(Imm<2> size, Imm<1> L, Imm<1> M, Imm<4> Vmlo, Imm<1> H, Vec Vn, Vec Vd);
     bool FMLA_elt_1(Imm<1> L, Imm<1> M, Imm<4> Vmlo, Imm<1> H, Vec Vn, Vec Vd);


### PR DESCRIPTION
These can be implemented in terms of the vector IR opcodes.