### PR TITLE
A64: Handle half-precision floating point in floating-point FCVT, FCVTL, and FCVTN

### DIFF
--- a/src/backend/x64/emit_x64_floating_point.cpp
+++ b/src/backend/x64/emit_x64_floating_point.cpp
@@ -1036,6 +1036,28 @@ void EmitX64::EmitFPCompare64(EmitContext& ctx, IR::Inst* inst) {
     ctx.reg_alloc.DefineValue(inst, nzcv);
 }
 
+void EmitX64::EmitFPHalfToDouble(EmitContext& ctx, IR::Inst* inst) {
+    auto args = ctx.reg_alloc.GetArgumentInfo(inst);
+    const auto rounding_mode = static_cast<FP::RoundingMode>(args[1].GetImmediateU8());
+
+    ctx.reg_alloc.HostCall(inst, args[0]);
+    code.mov(code.ABI_PARAM2.cvt32(), ctx.FPCR());
+    code.mov(code.ABI_PARAM3.cvt32(), static_cast<u32>(rounding_mode));
+    code.lea(code.ABI_PARAM4, code.ptr[code.r15 + code.GetJitStateInfo().offsetof_fpsr_exc]);
+    code.CallFunction(&FP::FPConvert<u64, u16>);
+}
+
+void EmitX64::EmitFPHalfToSingle(EmitContext& ctx, IR::Inst* inst) {
+    auto args = ctx.reg_alloc.GetArgumentInfo(inst);
+    const auto rounding_mode = static_cast<FP::RoundingMode>(args[1].GetImmediateU8());
+
+    ctx.reg_alloc.HostCall(inst, args[0]);
+    code.mov(code.ABI_PARAM2.cvt32(), ctx.FPCR());
+    code.mov(code.ABI_PARAM3.cvt32(), static_cast<u32>(rounding_mode));
+    code.lea(code.ABI_PARAM4, code.ptr[code.r15 + code.GetJitStateInfo().offsetof_fpsr_exc]);
+    code.CallFunction(&FP::FPConvert<u32, u16>);
+}
+
 void EmitX64::EmitFPSingleToDouble(EmitContext& ctx, IR::Inst* inst) {
     auto args = ctx.reg_alloc.GetArgumentInfo(inst);
     const auto rounding_mode = static_cast<FP::RoundingMode>(args[1].GetImmediateU8());
@@ -1056,6 +1078,28 @@ void EmitX64::EmitFPSingleToDouble(EmitContext& ctx, IR::Inst* inst) {
         code.lea(code.ABI_PARAM4, code.ptr[code.r15 + code.GetJitStateInfo().offsetof_fpsr_exc]);
         code.CallFunction(&FP::FPConvert<u64, u32>);
     }
+}
+
+void EmitX64::EmitFPSingleToHalf(EmitContext& ctx, IR::Inst* inst) {
+    auto args = ctx.reg_alloc.GetArgumentInfo(inst);
+    const auto rounding_mode = static_cast<FP::RoundingMode>(args[1].GetImmediateU8());
+
+    ctx.reg_alloc.HostCall(inst, args[0]);
+    code.mov(code.ABI_PARAM2.cvt32(), ctx.FPCR());
+    code.mov(code.ABI_PARAM3.cvt32(), static_cast<u32>(rounding_mode));
+    code.lea(code.ABI_PARAM4, code.ptr[code.r15 + code.GetJitStateInfo().offsetof_fpsr_exc]);
+    code.CallFunction(&FP::FPConvert<u16, u32>);
+}
+
+void EmitX64::EmitFPDoubleToHalf(EmitContext& ctx, IR::Inst* inst) {
+    auto args = ctx.reg_alloc.GetArgumentInfo(inst);
+    const auto rounding_mode = static_cast<FP::RoundingMode>(args[1].GetImmediateU8());
+
+    ctx.reg_alloc.HostCall(inst, args[0]);
+    code.mov(code.ABI_PARAM2.cvt32(), ctx.FPCR());
+    code.mov(code.ABI_PARAM3.cvt32(), static_cast<u32>(rounding_mode));
+    code.lea(code.ABI_PARAM4, code.ptr[code.r15 + code.GetJitStateInfo().offsetof_fpsr_exc]);
+    code.CallFunction(&FP::FPConvert<u16, u64>);
 }
 
 void EmitX64::EmitFPDoubleToSingle(EmitContext& ctx, IR::Inst* inst) {

--- a/src/common/fp/op/FPConvert.cpp
+++ b/src/common/fp/op/FPConvert.cpp
@@ -17,25 +17,17 @@
 
 namespace Dynarmic::FP {
 namespace {
-// We don't care about unreachable code warnings here
-// TODO: Remove this disabling of warnings when
-// half-float support is added.
-#ifdef _MSC_VER
-#pragma warning(disable:4702)
-#endif
 template <typename FPT_TO, typename FPT_FROM>
 FPT_TO FPConvertNaN(FPT_FROM op) {
     const bool sign = Common::Bit<Common::BitSize<FPT_FROM>() - 1>(op);
     const u64 frac = [op] {
         if constexpr (sizeof(FPT_FROM) == sizeof(u64)) {
             return Common::Bits<0, 50>(op);
-        }
-
-        if constexpr (sizeof(FPT_FROM) == sizeof(u32)) {
+        } else if constexpr (sizeof(FPT_FROM) == sizeof(u32)) {
             return u64{Common::Bits<0, 21>(op)} << 29;
+        } else {
+            return u64{Common::Bits<0, 8>(op)} << 42;
         }
-
-        return u64{Common::Bits<0, 8>(op)} << 42;
     }();
 
     const size_t dest_bit_size = Common::BitSize<FPT_TO>();
@@ -44,17 +36,12 @@ FPT_TO FPConvertNaN(FPT_FROM op) {
 
     if constexpr (sizeof(FPT_TO) == sizeof(u64)) {
         return FPT_TO(shifted_sign | exponent << 52 | frac);
-    }
-
-    if constexpr (sizeof(FPT_TO) == sizeof(u32)) {
+    } else if constexpr (sizeof(FPT_TO) == sizeof(u32)) {
         return FPT_TO(shifted_sign | exponent << 22 | Common::Bits<29, 50>(frac));
+    } else {
+        return FPT_TO(shifted_sign | exponent << 9 | Common::Bits<42, 50>(frac));
     }
-
-    return FPT_TO(shifted_sign | exponent << 9 | Common::Bits<42, 50>(frac));
 }
-#ifdef _MSC_VER
-#pragma warning(default:4702)
-#endif
 } // Anonymous namespace
 
 template <typename FPT_TO, typename FPT_FROM>
@@ -63,7 +50,7 @@ FPT_TO FPConvert(FPT_FROM op, FPCR fpcr, RoundingMode rounding_mode, FPSR& fpsr)
     const bool is_althp = Common::BitSize<FPT_TO>() == 16 && fpcr.AHP();
 
     if (type == FPType::SNaN || type == FPType::QNaN) {
-        FPT_TO result{};
+        std::uintmax_t result{};
 
         if (is_althp) {
             result = FPInfo<FPT_TO>::Zero(sign);
@@ -77,26 +64,30 @@ FPT_TO FPConvert(FPT_FROM op, FPCR fpcr, RoundingMode rounding_mode, FPSR& fpsr)
             FPProcessException(FPExc::InvalidOp, fpcr, fpsr);
         }
 
-        return result;
+        return FPT_TO(result);
     }
 
     if (type == FPType::Infinity) {
         if (is_althp) {
             FPProcessException(FPExc::InvalidOp, fpcr, fpsr);
-            return static_cast<FPT_TO>(u32{sign} << 15 | 0b111111111111111);
+            return FPT_TO(u32{sign} << 15 | 0b111111111111111);
         }
 
-        return FPInfo<FPT_TO>::Infinity(sign);
+        return FPT_TO(FPInfo<FPT_TO>::Infinity(sign));
     }
 
     if (type == FPType::Zero) {
-        return FPInfo<FPT_TO>::Zero(sign);
+        return FPT_TO(FPInfo<FPT_TO>::Zero(sign));
     }
 
     return FPRoundCV<FPT_TO>(value, fpcr, rounding_mode, fpsr);
 }
 
-template u64 FPConvert<u64, u32>(u32 op, FPCR fpcr, RoundingMode rounding_mode, FPSR& fpsr);
+template u16 FPConvert<u16, u32>(u32 op, FPCR fpcr, RoundingMode rounding_mode, FPSR& fpsr);
+template u16 FPConvert<u16, u64>(u64 op, FPCR fpcr, RoundingMode rounding_mode, FPSR& fpsr);
+template u32 FPConvert<u32, u16>(u16 op, FPCR fpcr, RoundingMode rounding_mode, FPSR& fpsr);
 template u32 FPConvert<u32, u64>(u64 op, FPCR fpcr, RoundingMode rounding_mode, FPSR& fpsr);
+template u64 FPConvert<u64, u16>(u16 op, FPCR fpcr, RoundingMode rounding_mode, FPSR& fpsr);
+template u64 FPConvert<u64, u32>(u32 op, FPCR fpcr, RoundingMode rounding_mode, FPSR& fpsr);
 
 } // namespace Dynarmic::FP

--- a/src/common/fp/op/FPConvert.cpp
+++ b/src/common/fp/op/FPConvert.cpp
@@ -35,7 +35,7 @@ FPT_TO FPConvertNaN(FPT_FROM op) {
     const u64 exponent = Common::Ones<u64>(dest_bit_size - FPInfo<FPT_TO>::explicit_mantissa_width);
 
     if constexpr (sizeof(FPT_TO) == sizeof(u64)) {
-        return FPT_TO(shifted_sign | exponent << 52 | frac);
+        return FPT_TO(shifted_sign | exponent << 51 | frac);
     } else if constexpr (sizeof(FPT_TO) == sizeof(u32)) {
         return FPT_TO(shifted_sign | exponent << 22 | Common::Bits<29, 50>(frac));
     } else {

--- a/src/common/fp/unpacked.h
+++ b/src/common/fp/unpacked.h
@@ -63,7 +63,7 @@ std::tuple<FPType, bool, FPUnpacked> FPUnpack(FPT op, FPCR fpcr, FPSR& fpsr) {
 template<typename FPT>
 std::tuple<FPType, bool, FPUnpacked> FPUnpackCV(FPT op, FPCR fpcr, FPSR& fpsr) {
     fpcr.FZ16(false);
-    return FPUnpack(op, fpcr, fpsr);
+    return FPUnpackBase(op, fpcr, fpsr);
 }
 
 template<typename FPT>

--- a/src/frontend/A64/translate/impl/floating_point_data_processing_one_register.cpp
+++ b/src/frontend/A64/translate/impl/floating_point_data_processing_one_register.cpp
@@ -112,15 +112,18 @@ bool TranslatorVisitor::FCVT_float(Imm<2> type, Imm<2> opc, Vec Vn, Vec Vd) {
     case 16:
         switch (*dstsize) {
         case 32:
-            return InterpretThisInstruction();
+            result = ir.FPHalfToSingle(operand, rounding_mode);
+            break;
         case 64:
-            return InterpretThisInstruction();
+            result = ir.FPHalfToDouble(operand, rounding_mode);
+            break;
         }
         break;
     case 32:
         switch (*dstsize) {
         case 16:
-            return InterpretThisInstruction();
+            result = ir.FPSingleToHalf(operand, rounding_mode);
+            break;
         case 64:
             result = ir.FPSingleToDouble(operand, rounding_mode);
             break;
@@ -129,7 +132,8 @@ bool TranslatorVisitor::FCVT_float(Imm<2> type, Imm<2> opc, Vec Vn, Vec Vd) {
     case 64:
     switch (*dstsize) {
         case 16:
-            return InterpretThisInstruction();
+            result = ir.FPDoubleToHalf(operand, rounding_mode);
+            break;
         case 32:
             result = ir.FPDoubleToSingle(operand, rounding_mode);
             break;

--- a/src/frontend/A64/translate/impl/simd_two_register_misc.cpp
+++ b/src/frontend/A64/translate/impl/simd_two_register_misc.cpp
@@ -342,19 +342,24 @@ bool TranslatorVisitor::FCMLT_4(bool Q, bool sz, Vec Vn, Vec Vd) {
 }
 
 bool TranslatorVisitor::FCVTL(bool Q, bool sz, Vec Vn, Vec Vd) {
-    // Half-precision not handled directly.
-    if (!sz) {
-        return InterpretThisInstruction();
-    }
+    const size_t esize = sz ? 32 : 16;
+    const size_t datasize = 64;
+    const size_t num_elements = datasize / esize;
 
     const IR::U128 part = Vpart(64, Vn, Q);
     const auto rounding_mode = ir.current_location->FPCR().RMode();
     IR::U128 result = ir.ZeroVector();
 
-    for (size_t i = 0; i < 2; i++) {
-        const IR::U64 element = ir.FPSingleToDouble(ir.VectorGetElement(32, part, i), rounding_mode);
+    for (size_t i = 0; i < num_elements; i++) {
+        IR::U16U32U64 element = ir.VectorGetElement(esize, part, i);
 
-        result = ir.VectorSetElement(64, result, i, element);
+        if (esize == 16) {
+            element = ir.FPHalfToSingle(element, rounding_mode);
+        } else if (esize == 32) {
+            element = ir.FPSingleToDouble(element, rounding_mode);
+        }
+
+        result = ir.VectorSetElement(2 * esize, result, i, element);
     }
 
     V(128, Vd, result);

--- a/src/frontend/A64/translate/impl/simd_two_register_misc.cpp
+++ b/src/frontend/A64/translate/impl/simd_two_register_misc.cpp
@@ -362,22 +362,27 @@ bool TranslatorVisitor::FCVTL(bool Q, bool sz, Vec Vn, Vec Vd) {
 }
 
 bool TranslatorVisitor::FCVTN(bool Q, bool sz, Vec Vn, Vec Vd) {
-    // Half-precision not handled directly.
-    if (!sz) {
-        return InterpretThisInstruction();
-    }
+    const size_t datasize = 64;
+    const size_t esize = sz ? 32 : 16;
+    const size_t num_elements = datasize / esize;
 
     const IR::U128 operand = V(128, Vn);
     const auto rounding_mode = ir.current_location->FPCR().RMode();
     IR::U128 result = ir.ZeroVector();
 
-    for (size_t i = 0; i < 2; i++) {
-        const IR::U32 element = ir.FPDoubleToSingle(ir.VectorGetElement(64, operand, i), rounding_mode);
+    for (size_t i = 0; i < num_elements; i++) {
+        IR::U16U32U64 element = ir.VectorGetElement(2 * esize, operand, i);
 
-        result = ir.VectorSetElement(32, result, i, element);
+        if (esize == 16) {
+            element = ir.FPSingleToHalf(element, rounding_mode);
+        } else if (esize == 32) {
+            element = ir.FPDoubleToSingle(element, rounding_mode);
+        }
+
+        result = ir.VectorSetElement(esize, result, i, element);
     }
 
-    Vpart(64, Vd, Q, result);
+    Vpart(datasize, Vd, Q, result);
     return true;
 }
 

--- a/src/frontend/ir/ir_emitter.cpp
+++ b/src/frontend/ir/ir_emitter.cpp
@@ -1955,12 +1955,28 @@ U32U64 IREmitter::FPSub(const U32U64& a, const U32U64& b, bool fpcr_controlled) 
     }
 }
 
+U16 IREmitter::FPDoubleToHalf(const U64& a, FP::RoundingMode rounding) {
+    return Inst<U16>(Opcode::FPDoubleToHalf, a, Imm8(static_cast<u8>(rounding)));
+}
+
 U32 IREmitter::FPDoubleToSingle(const U64& a, FP::RoundingMode rounding) {
     return Inst<U32>(Opcode::FPDoubleToSingle, a, Imm8(static_cast<u8>(rounding)));
 }
 
+U64 IREmitter::FPHalfToDouble(const U16& a, FP::RoundingMode rounding) {
+    return Inst<U64>(Opcode::FPHalfToDouble, a, Imm8(static_cast<u8>(rounding)));
+}
+
+U32 IREmitter::FPHalfToSingle(const U16& a, FP::RoundingMode rounding) {
+    return Inst<U32>(Opcode::FPHalfToSingle, a, Imm8(static_cast<u8>(rounding)));
+}
+
 U64 IREmitter::FPSingleToDouble(const U32& a, FP::RoundingMode rounding) {
     return Inst<U64>(Opcode::FPSingleToDouble, a, Imm8(static_cast<u8>(rounding)));
+}
+
+U16 IREmitter::FPSingleToHalf(const U32& a, FP::RoundingMode rounding) {
+    return Inst<U16>(Opcode::FPSingleToHalf, a, Imm8(static_cast<u8>(rounding)));
 }
 
 U32 IREmitter::FPToFixedS32(const U32U64& a, size_t fbits, FP::RoundingMode rounding) {

--- a/src/frontend/ir/ir_emitter.h
+++ b/src/frontend/ir/ir_emitter.h
@@ -312,7 +312,11 @@ public:
     U32U64 FPRSqrtStepFused(const U32U64& a, const U32U64& b);
     U32U64 FPSqrt(const U32U64& a);
     U32U64 FPSub(const U32U64& a, const U32U64& b, bool fpcr_controlled);
+    U16 FPDoubleToHalf(const U64& a, FP::RoundingMode rounding);
     U32 FPDoubleToSingle(const U64& a, FP::RoundingMode rounding);
+    U64 FPHalfToDouble(const U16& a, FP::RoundingMode rounding);
+    U32 FPHalfToSingle(const U16& a, FP::RoundingMode rounding);
+    U16 FPSingleToHalf(const U32& a, FP::RoundingMode rounding);
     U64 FPSingleToDouble(const U32& a, FP::RoundingMode rounding);
     U32 FPToFixedS32(const U32U64& a, size_t fbits, FP::RoundingMode rounding);
     U64 FPToFixedS64(const U32U64& a, size_t fbits, FP::RoundingMode rounding);

--- a/src/frontend/ir/microinstruction.cpp
+++ b/src/frontend/ir/microinstruction.cpp
@@ -288,7 +288,11 @@ bool Inst::ReadsFromAndWritesToFPSRCumulativeExceptionBits() const {
     case Opcode::FPSqrt64:
     case Opcode::FPSub32:
     case Opcode::FPSub64:
+    case Opcode::FPHalfToDouble:
+    case Opcode::FPHalfToSingle:
     case Opcode::FPSingleToDouble:
+    case Opcode::FPSingleToHalf:
+    case Opcode::FPDoubleToHalf:
     case Opcode::FPDoubleToSingle:
     case Opcode::FPDoubleToFixedS32:
     case Opcode::FPDoubleToFixedS64:

--- a/src/frontend/ir/opcodes.inc
+++ b/src/frontend/ir/opcodes.inc
@@ -503,7 +503,11 @@ OPCODE(FPSub32,                                             U32,            U32,
 OPCODE(FPSub64,                                             U64,            U64,            U64                                             )
 
 // Floating-point conversions
+OPCODE(FPHalfToDouble,                                      U64,            U16,            U8                                              )
+OPCODE(FPHalfToSingle,                                      U32,            U16,            U8                                              )
 OPCODE(FPSingleToDouble,                                    U64,            U32,            U8                                              )
+OPCODE(FPSingleToHalf,                                      U16,            U32,            U8                                              )
+OPCODE(FPDoubleToHalf,                                      U16,            U64,            U8                                              )
 OPCODE(FPDoubleToSingle,                                    U32,            U64,            U8                                              )
 OPCODE(FPDoubleToFixedS32,                                  U32,            U64,            U8,             U8                              )
 OPCODE(FPDoubleToFixedS64,                                  U64,            U64,            U8,             U8                              )


### PR DESCRIPTION
Knocks out a handful of fallbacks to the interpreter.

On top of implementing half-precision floating-point paths for the relevant instructions, this also fixes two bugs that slipped through in the FPUnpackCV and FPConvert implementations (my bad).