### PR TITLE
{common/fp, backend/x64}: Prevent undefined left shifts where applicable

### DIFF
--- a/src/backend/x64/emit_x64_vector.cpp
+++ b/src/backend/x64/emit_x64_vector.cpp
@@ -3838,7 +3838,7 @@ static bool VectorSignedSaturatedShiftLeft(VectorArray<T>& dst, const VectorArra
             dst[i] = saturate(element);
             qc_flag = true;
         } else {
-            const T shifted = element << shift;
+            const T shifted = T(U(element) << shift);
 
             if ((shifted >> shift) != element) {
                 dst[i] = saturate(element);

--- a/src/common/fp/op/FPRecipExponent.cpp
+++ b/src/common/fp/op/FPRecipExponent.cpp
@@ -48,8 +48,9 @@ FPT FPRecipExponent(FPT op, FPCR fpcr, FPSR& fpsr) {
     }
 
     // Infinities and normals
-    const auto negated_exponent = (~exponent << FPInfo<FPT>::explicit_mantissa_width) & FPInfo<FPT>::exponent_mask;
-    return FPT(sign_bits | negated_exponent);
+    const FPT negated_exponent = FPT(~exponent);
+    const FPT adjusted_exponent = FPT(negated_exponent << FPInfo<FPT>::explicit_mantissa_width) & FPInfo<FPT>::exponent_mask;
+    return FPT(sign_bits | adjusted_exponent);
 }
 
 template u16 FPRecipExponent<u16>(u16 op, FPCR fpcr, FPSR& fpsr);


### PR DESCRIPTION
There were two cases where negative signed left shifts could occur (which are undefined behavior). This prevents those cases by casting to unsigned before the shift to indicate that said shifts are desirable.