### PR TITLE
A64: Implement scalar variant of SQSHL (immediate)

### DIFF
--- a/src/frontend/A64/decoder/a64.inc
+++ b/src/frontend/A64/decoder/a64.inc
@@ -512,7 +512,7 @@ INST(SSRA_1,                 "SSRA",                                      "01011
 INST(SRSHR_1,                "SRSHR",                                     "010111110IIIIiii001001nnnnnddddd")
 INST(SRSRA_1,                "SRSRA",                                     "010111110IIIIiii001101nnnnnddddd")
 INST(SHL_1,                  "SHL",                                       "010111110IIIIiii010101nnnnnddddd")
-//INST(SQSHL_imm_1,            "SQSHL (immediate)",                         "010111110IIIIiii011101nnnnnddddd")
+INST(SQSHL_imm_1,            "SQSHL (immediate)",                         "010111110IIIIiii011101nnnnnddddd")
 INST(SQSHRN_1,               "SQSHRN, SQSHRN2",                           "010111110IIIIiii100101nnnnnddddd")
 //INST(SQRSHRN_1,              "SQRSHRN, SQRSHRN2",                         "010111110IIIIiii100111nnnnnddddd")
 INST(SCVTF_fix_1,            "SCVTF (vector, fixed-point)",               "010111110IIIIiii111001nnnnnddddd")

--- a/src/frontend/A64/translate/impl/simd_scalar_shift_by_immediate.cpp
+++ b/src/frontend/A64/translate/impl/simd_scalar_shift_by_immediate.cpp
@@ -253,6 +253,22 @@ bool TranslatorVisitor::SRI_1(Imm<4> immh, Imm<3> immb, Vec Vn, Vec Vd) {
     return ShiftAndInsert(*this, immh, immb, Vn, Vd, ShiftDirection::Right);
 }
 
+bool TranslatorVisitor::SQSHL_imm_1(Imm<4> immh, Imm<3> immb, Vec Vn, Vec Vd) {
+    if (immh == 0b0000) {
+        return UnallocatedEncoding();
+    }
+
+    const size_t esize = 8U << Common::HighestSetBit(immh.ZeroExtend());
+    const size_t shift_amount = concatenate(immh, immb).ZeroExtend() - esize;
+
+    const IR::U128 operand = ir.ZeroExtendToQuad(V_scalar(esize, Vn));
+    const IR::U128 shift = ir.ZeroExtendToQuad(I(esize, shift_amount));
+    const IR::U128 result = ir.VectorSignedSaturatedShiftLeft(esize, operand, shift);
+
+    ir.SetQ(Vd, result);
+    return true;
+}
+
 bool TranslatorVisitor::SQSHRN_1(Imm<4> immh, Imm<3> immb, Vec Vn, Vec Vd) {
     return ShiftRightNarrowing(*this, immh, immb, Vn, Vd, Narrowing::SaturateToSigned, Signedness::Signed);
 }


### PR DESCRIPTION
This can be handled in terms of the vector variant for the time being.