### PR TITLE
A64: Implement UQSHL (immediate)'s scalar variant

### DIFF
--- a/src/frontend/A64/decoder/a64.inc
+++ b/src/frontend/A64/decoder/a64.inc
@@ -524,7 +524,7 @@ INST(URSRA_1,                "URSRA",                                     "01111
 INST(SRI_1,                  "SRI",                                       "011111110IIIIiii010001nnnnnddddd")
 INST(SLI_1,                  "SLI",                                       "011111110IIIIiii010101nnnnnddddd")
 //INST(SQSHLU_1,               "SQSHLU",                                    "011111110IIIIiii011001nnnnnddddd")
-//INST(UQSHL_imm_1,            "UQSHL (immediate)",                         "011111110IIIIiii011101nnnnnddddd")
+INST(UQSHL_imm_1,            "UQSHL (immediate)",                         "011111110IIIIiii011101nnnnnddddd")
 INST(SQSHRUN_1,              "SQSHRUN, SQSHRUN2",                         "011111110IIIIiii100001nnnnnddddd")
 //INST(SQRSHRUN_1,             "SQRSHRUN, SQRSHRUN2",                       "011111110IIIIiii100011nnnnnddddd")
 INST(UQSHRN_1,               "UQSHRN, UQSHRN2",                           "011111110IIIIiii100101nnnnnddddd")

--- a/src/frontend/A64/translate/impl/simd_scalar_shift_by_immediate.cpp
+++ b/src/frontend/A64/translate/impl/simd_scalar_shift_by_immediate.cpp
@@ -32,7 +32,7 @@ enum class FloatConversionDirection {
 
 bool SaturatingShiftLeft(TranslatorVisitor& v, Imm<4> immh, Imm<3> immb, Vec Vn, Vec Vd, Signedness sign) {
     if (immh == 0b0000) {
-        return v.UnallocatedEncoding();
+        return v.ReservedValue();
     }
 
     const size_t esize = 8U << Common::HighestSetBit(immh.ZeroExtend());

--- a/src/frontend/A64/translate/impl/simd_scalar_shift_by_immediate.cpp
+++ b/src/frontend/A64/translate/impl/simd_scalar_shift_by_immediate.cpp
@@ -30,6 +30,22 @@ enum class FloatConversionDirection {
     FloatToFixed,
 };
 
+bool SaturatingShiftLeft(TranslatorVisitor& v, Imm<4> immh, Imm<3> immb, Vec Vn, Vec Vd) {
+    if (immh == 0b0000) {
+        return v.UnallocatedEncoding();
+    }
+
+    const size_t esize = 8U << Common::HighestSetBit(immh.ZeroExtend());
+    const size_t shift_amount = concatenate(immh, immb).ZeroExtend() - esize;
+
+    const IR::U128 operand = v.ir.ZeroExtendToQuad(v.V_scalar(esize, Vn));
+    const IR::U128 shift = v.ir.ZeroExtendToQuad(v.I(esize, shift_amount));
+    const IR::U128 result = v.ir.VectorSignedSaturatedShiftLeft(esize, operand, shift);
+
+    v.ir.SetQ(Vd, result);
+    return true;
+}
+
 bool ShiftRight(TranslatorVisitor& v, Imm<4> immh, Imm<3> immb, Vec Vn, Vec Vd,
                 ShiftExtraBehavior behavior, Signedness signedness) {
     if (!immh.Bit<3>()) {
@@ -254,19 +270,7 @@ bool TranslatorVisitor::SRI_1(Imm<4> immh, Imm<3> immb, Vec Vn, Vec Vd) {
 }
 
 bool TranslatorVisitor::SQSHL_imm_1(Imm<4> immh, Imm<3> immb, Vec Vn, Vec Vd) {
-    if (immh == 0b0000) {
-        return UnallocatedEncoding();
-    }
-
-    const size_t esize = 8U << Common::HighestSetBit(immh.ZeroExtend());
-    const size_t shift_amount = concatenate(immh, immb).ZeroExtend() - esize;
-
-    const IR::U128 operand = ir.ZeroExtendToQuad(V_scalar(esize, Vn));
-    const IR::U128 shift = ir.ZeroExtendToQuad(I(esize, shift_amount));
-    const IR::U128 result = ir.VectorSignedSaturatedShiftLeft(esize, operand, shift);
-
-    ir.SetQ(Vd, result);
-    return true;
+    return SaturatingShiftLeft(*this, immh, immb, Vn, Vd);
 }
 
 bool TranslatorVisitor::SQSHRN_1(Imm<4> immh, Imm<3> immb, Vec Vn, Vec Vd) {


### PR DESCRIPTION
Like SQSHL's immediate scalar variant, we can also implement UQSHL's immediate scalar variant in terms of the vector variant for the time being.