### PR TITLE
CMakeLists: Allow importing dynarmic build trees into other CMake projects

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -291,3 +291,5 @@ endif()
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     target_compile_definitions(dynarmic PRIVATE FMT_USE_WINDOWS_H=0)
 endif()
+
+export(TARGETS dynarmic boost fmt xbyak FILE "dynarmic-config.cmake")


### PR DESCRIPTION
This allows for cleaner integration of dynarmic as a library into other projects. Currently, the recommended solution appears to be `add_subdirectory`ing dynarmic into the parent project, but this leaks parent configuration into dynarmic and causes unnecessary rebuilds of dynarmic.

With this change, a file named `dynarmic-config.cmake` will be created as part of the dynarmic build process, so an external dynarmic build tree (when added to CMAKE_PREFIX_PATH) can be imported into other projects using a simple `find_package(dynarmic REQUIRED)`. Coincidentally, and totally not the reason I'm proposing this change, this is how the package manager Conan imports dependencies.
