### PR TITLE
ir_opt: Mark locals as const where applicable

### DIFF
--- a/src/ir_opt/a32_constant_memory_reads_pass.cpp
+++ b/src/ir_opt/a32_constant_memory_reads_pass.cpp
@@ -16,52 +16,56 @@ void A32ConstantMemoryReads(IR::Block& block, A32::UserCallbacks* cb) {
     for (auto& inst : block) {
         switch (inst.GetOpcode()) {
         case IR::Opcode::A32SetCFlag: {
-            IR::Value arg = inst.GetArg(0);
+            const IR::Value arg = inst.GetArg(0);
             if (!arg.IsImmediate() && arg.GetInst()->GetOpcode() == IR::Opcode::A32GetCFlag) {
                 inst.Invalidate();
             }
             break;
         }
         case IR::Opcode::A32ReadMemory8: {
-            if (!inst.AreAllArgsImmediates())
+            if (!inst.AreAllArgsImmediates()) {
                 break;
+            }
 
-            u32 vaddr = inst.GetArg(0).GetU32();
+            const u32 vaddr = inst.GetArg(0).GetU32();
             if (cb->IsReadOnlyMemory(vaddr)) {
-                u8 value_from_memory = cb->MemoryRead8(vaddr);
+                const u8 value_from_memory = cb->MemoryRead8(vaddr);
                 inst.ReplaceUsesWith(IR::Value{value_from_memory});
             }
             break;
         }
         case IR::Opcode::A32ReadMemory16: {
-            if (!inst.AreAllArgsImmediates())
+            if (!inst.AreAllArgsImmediates()) {
                 break;
+            }
 
-            u32 vaddr = inst.GetArg(0).GetU32();
+            const u32 vaddr = inst.GetArg(0).GetU32();
             if (cb->IsReadOnlyMemory(vaddr)) {
-                u16 value_from_memory = cb->MemoryRead16(vaddr);
+                const u16 value_from_memory = cb->MemoryRead16(vaddr);
                 inst.ReplaceUsesWith(IR::Value{value_from_memory});
             }
             break;
         }
         case IR::Opcode::A32ReadMemory32: {
-            if (!inst.AreAllArgsImmediates())
+            if (!inst.AreAllArgsImmediates()) {
                 break;
+            }
 
-            u32 vaddr = inst.GetArg(0).GetU32();
+            const u32 vaddr = inst.GetArg(0).GetU32();
             if (cb->IsReadOnlyMemory(vaddr)) {
-                u32 value_from_memory = cb->MemoryRead32(vaddr);
+                const u32 value_from_memory = cb->MemoryRead32(vaddr);
                 inst.ReplaceUsesWith(IR::Value{value_from_memory});
             }
             break;
         }
         case IR::Opcode::A32ReadMemory64: {
-            if (!inst.AreAllArgsImmediates())
+            if (!inst.AreAllArgsImmediates()) {
                 break;
+            }
 
-            u32 vaddr = inst.GetArg(0).GetU32();
+            const u32 vaddr = inst.GetArg(0).GetU32();
             if (cb->IsReadOnlyMemory(vaddr)) {
-                u64 value_from_memory = cb->MemoryRead64(vaddr);
+                const u64 value_from_memory = cb->MemoryRead64(vaddr);
                 inst.ReplaceUsesWith(IR::Value{value_from_memory});
             }
             break;

--- a/src/ir_opt/a32_get_set_elimination_pass.cpp
+++ b/src/ir_opt/a32_get_set_elimination_pass.cpp
@@ -56,48 +56,49 @@ void A32GetSetElimination(IR::Block& block) {
     for (auto inst = block.begin(); inst != block.end(); ++inst) {
         switch (inst->GetOpcode()) {
         case IR::Opcode::A32SetRegister: {
-            A32::Reg reg = inst->GetArg(0).GetA32RegRef();
-            if (reg == A32::Reg::PC)
+            const A32::Reg reg = inst->GetArg(0).GetA32RegRef();
+            if (reg == A32::Reg::PC) {
                 break;
-            size_t reg_index = static_cast<size_t>(reg);
+            }
+            const auto reg_index = static_cast<size_t>(reg);
             do_set(reg_info[reg_index], inst->GetArg(1), inst);
             break;
         }
         case IR::Opcode::A32GetRegister: {
-            A32::Reg reg = inst->GetArg(0).GetA32RegRef();
+            const A32::Reg reg = inst->GetArg(0).GetA32RegRef();
             ASSERT(reg != A32::Reg::PC);
-            size_t reg_index = static_cast<size_t>(reg);
+            const size_t reg_index = static_cast<size_t>(reg);
             do_get(reg_info[reg_index], inst);
             break;
         }
         case IR::Opcode::A32SetExtendedRegister32: {
-            A32::ExtReg reg = inst->GetArg(0).GetA32ExtRegRef();
-            size_t reg_index = A32::RegNumber(reg);
+            const A32::ExtReg reg = inst->GetArg(0).GetA32ExtRegRef();
+            const size_t reg_index = A32::RegNumber(reg);
             do_set(ext_reg_singles_info[reg_index], inst->GetArg(1), inst);
 
-            size_t doubles_reg_index = reg_index / 2;
+            const size_t doubles_reg_index = reg_index / 2;
             if (doubles_reg_index < ext_reg_doubles_info.size()) {
                 ext_reg_doubles_info[doubles_reg_index] = {};
             }
             break;
         }
         case IR::Opcode::A32GetExtendedRegister32: {
-            A32::ExtReg reg = inst->GetArg(0).GetA32ExtRegRef();
-            size_t reg_index = A32::RegNumber(reg);
+            const A32::ExtReg reg = inst->GetArg(0).GetA32ExtRegRef();
+            const size_t reg_index = A32::RegNumber(reg);
             do_get(ext_reg_singles_info[reg_index], inst);
 
-            size_t doubles_reg_index = reg_index / 2;
+            const size_t doubles_reg_index = reg_index / 2;
             if (doubles_reg_index < ext_reg_doubles_info.size()) {
                 ext_reg_doubles_info[doubles_reg_index] = {};
             }
             break;
         }
         case IR::Opcode::A32SetExtendedRegister64: {
-            A32::ExtReg reg = inst->GetArg(0).GetA32ExtRegRef();
-            size_t reg_index = A32::RegNumber(reg);
+            const A32::ExtReg reg = inst->GetArg(0).GetA32ExtRegRef();
+            const size_t reg_index = A32::RegNumber(reg);
             do_set(ext_reg_doubles_info[reg_index], inst->GetArg(1), inst);
 
-            size_t singles_reg_index = reg_index * 2;
+            const size_t singles_reg_index = reg_index * 2;
             if (singles_reg_index < ext_reg_singles_info.size()) {
                 ext_reg_singles_info[singles_reg_index] = {};
                 ext_reg_singles_info[singles_reg_index+1] = {};
@@ -105,11 +106,11 @@ void A32GetSetElimination(IR::Block& block) {
             break;
         }
         case IR::Opcode::A32GetExtendedRegister64: {
-            A32::ExtReg reg = inst->GetArg(0).GetA32ExtRegRef();
-            size_t reg_index = A32::RegNumber(reg);
+            const A32::ExtReg reg = inst->GetArg(0).GetA32ExtRegRef();
+            const size_t reg_index = A32::RegNumber(reg);
             do_get(ext_reg_doubles_info[reg_index], inst);
 
-            size_t singles_reg_index = reg_index * 2;
+            const size_t singles_reg_index = reg_index * 2;
             if (singles_reg_index < ext_reg_singles_info.size()) {
                 ext_reg_singles_info[singles_reg_index] = {};
                 ext_reg_singles_info[singles_reg_index+1] = {};

--- a/src/ir_opt/a64_callback_config_pass.cpp
+++ b/src/ir_opt/a64_callback_config_pass.cpp
@@ -25,7 +25,7 @@ void A64CallbackConfigPass(IR::Block& block, const A64::UserConfig& conf) {
             continue;
         }
 
-        auto op = static_cast<A64::DataCacheOperation>(inst.GetArg(0).GetU64());
+        const auto op = static_cast<A64::DataCacheOperation>(inst.GetArg(0).GetU64());
         if (op == A64::DataCacheOperation::ZeroByVA) {
             A64::IREmitter ir{block};
             ir.SetInsertionPoint(&inst);

--- a/src/ir_opt/verification_pass.cpp
+++ b/src/ir_opt/verification_pass.cpp
@@ -20,8 +20,8 @@ void VerificationPass(const IR::Block& block) {
     for (const auto& inst : block) {
         const size_t num_args = inst.NumArgs();
         for (size_t i = 0; i < num_args; i++) {
-            IR::Type t1 = inst.GetArg(i).GetType();
-            IR::Type t2 = IR::GetArgTypeOf(inst.GetOpcode(), i);
+            const IR::Type t1 = inst.GetArg(i).GetType();
+            const IR::Type t2 = IR::GetArgTypeOf(inst.GetOpcode(), i);
             if (!IR::AreTypesCompatible(t1, t2)) {
                 puts(IR::DumpBlock(block).c_str());
                 ASSERT(false);


### PR DESCRIPTION
Makes the immutable state within the passes more explicit.