### PR TITLE
A64/impl: Reorganize peculiar void use in V_scalar

### DIFF
--- a/src/frontend/A64/translate/impl/impl.cpp
+++ b/src/frontend/A64/translate/impl/impl.cpp
@@ -226,7 +226,8 @@ IR::UAnyU128 TranslatorVisitor::V_scalar(size_t bitsize, Vec vec) {
 
 void TranslatorVisitor::V_scalar(size_t bitsize, Vec vec, IR::UAnyU128 value) {
     if (bitsize == 128) {
-        return V(128, vec, value);
+        V(128, vec, value);
+        return;
     }
     // TODO: Optimize
     ir.SetQ(vec, ir.ZeroExtendToQuad(value));


### PR DESCRIPTION
To a reader this might look particularly strange, given the function itself has a void return value, but this is actually valid, given the function in the return statement also has a void return value.

This instead alters it to be a little easier to parse and potentially be a little less confusing at a glance.