### PR TITLE
general: Replace unreachable-imitating assertions with UNREACHABLE()

### DIFF
--- a/src/backend/x64/a32_emit_x64.cpp
+++ b/src/backend/x64/a32_emit_x64.cpp
@@ -1018,7 +1018,7 @@ void A32EmitX64::EmitA32CoprocSendOneWord(A32EmitContext& ctx, IR::Inst* inst) {
         return;
     }
     default:
-        ASSERT_MSG(false, "Unreachable");
+        UNREACHABLE();
     }
 }
 
@@ -1060,7 +1060,7 @@ void A32EmitX64::EmitA32CoprocSendTwoWords(A32EmitContext& ctx, IR::Inst* inst) 
         return;
     }
     default:
-        ASSERT_MSG(false, "Unreachable");
+        UNREACHABLE();
     }
 }
 
@@ -1102,7 +1102,7 @@ void A32EmitX64::EmitA32CoprocGetOneWord(A32EmitContext& ctx, IR::Inst* inst) {
         return;
     }
     default:
-        ASSERT_MSG(false, "Unreachable");
+        UNREACHABLE();
     }
 }
 
@@ -1147,7 +1147,7 @@ void A32EmitX64::EmitA32CoprocGetTwoWords(A32EmitContext& ctx, IR::Inst* inst) {
         return;
     }
     default:
-        ASSERT_MSG(false, "Unreachable");
+        UNREACHABLE();
     }
 }
 

--- a/src/backend/x64/emit_x64.cpp
+++ b/src/backend/x64/emit_x64.cpp
@@ -129,7 +129,7 @@ void EmitX64::EmitGetNZCVFromOp(EmitContext& ctx, IR::Inst* inst) {
         case IR::Type::U64:
             return 64;
         default:
-            ASSERT_MSG(false, "Unreachable");
+            UNREACHABLE();
             return 0;
         }
     }();

--- a/src/backend/x64/oparg.h
+++ b/src/backend/x64/oparg.h
@@ -26,7 +26,7 @@ struct OpArg {
         case Type::Reg:
             return inner_reg;
         }
-        ASSERT_MSG(false, "Unreachable");
+        UNREACHABLE();
     }
 
     void setBit(int bits) {
@@ -56,7 +56,7 @@ struct OpArg {
                 return;
             }
         }
-        ASSERT_MSG(false, "Unreachable");
+        UNREACHABLE();
     }
 
 private:

--- a/src/frontend/A32/translate/translate_arm.cpp
+++ b/src/frontend/A32/translate/translate_arm.cpp
@@ -173,7 +173,7 @@ IR::ResultAndCarry<IR::U32> ArmTranslatorVisitor::EmitImmShift(IR::U32 value, Sh
         else
             return ir.RotateRightExtended(value, carry_in);
     }
-    ASSERT_MSG(false, "Unreachable");
+    UNREACHABLE();
     return {};
 }
 
@@ -188,7 +188,7 @@ IR::ResultAndCarry<IR::U32> ArmTranslatorVisitor::EmitRegShift(IR::U32 value, Sh
     case ShiftType::ROR:
         return ir.RotateRight(value, amount, carry_in);
     }
-    ASSERT_MSG(false, "Unreachable");
+    UNREACHABLE();
     return {};
 }
 

--- a/src/frontend/A64/translate/impl/impl.cpp
+++ b/src/frontend/A64/translate/impl/impl.cpp
@@ -368,7 +368,7 @@ IR::U32U64 TranslatorVisitor::ShiftReg(size_t bitsize, Reg reg, Imm<2> shift, IR
     case 0b11:
         return ir.RotateRight(result, amount);
     }
-    ASSERT_MSG(false, "Unreachable");
+    UNREACHABLE();
     return {};
 }
 
@@ -432,7 +432,7 @@ IR::U32U64 TranslatorVisitor::ExtendReg(size_t bitsize, Reg reg, Imm<3> option, 
         break;
     }
     default:
-        ASSERT_MSG(false, "Unreachable");
+        UNREACHABLE();
     }
 
     if (len < bitsize) {

--- a/src/frontend/ir/ir_emitter.cpp
+++ b/src/frontend/ir/ir_emitter.cpp
@@ -330,7 +330,7 @@ U64 IREmitter::SignExtendToLong(const UAny& a) {
     case Type::U64:
         return U64(a);
     default:
-        ASSERT_MSG(false, "Unreachable");
+        UNREACHABLE();
         return {};
     }
 }
@@ -346,7 +346,7 @@ U32 IREmitter::SignExtendToWord(const UAny& a) {
     case Type::U64:
         return Inst<U32>(Opcode::LeastSignificantWord, a);
     default:
-        ASSERT_MSG(false, "Unreachable");
+        UNREACHABLE();
         return {};
     }
 }
@@ -374,7 +374,7 @@ U64 IREmitter::ZeroExtendToLong(const UAny& a) {
     case Type::U64:
         return U64(a);
     default:
-        ASSERT_MSG(false, "Unreachable");
+        UNREACHABLE();
         return {};
     }
 }
@@ -390,7 +390,7 @@ U32 IREmitter::ZeroExtendToWord(const UAny& a) {
     case Type::U64:
         return Inst<U32>(Opcode::LeastSignificantWord, a);
     default:
-        ASSERT_MSG(false, "Unreachable");
+        UNREACHABLE();
         return {};
     }
 }
@@ -817,7 +817,7 @@ UAny IREmitter::VectorGetElement(size_t esize, const U128& a, size_t index) {
     case 64:
         return Inst<U64>(Opcode::VectorGetElement64, a, Imm8(static_cast<u8>(index)));
     default:
-        ASSERT_MSG(false, "Unreachable");
+        UNREACHABLE();
         return {};
     }
 }
@@ -834,7 +834,7 @@ U128 IREmitter::VectorSetElement(size_t esize, const U128& a, size_t index, cons
     case 64:
         return Inst<U128>(Opcode::VectorSetElement64, a, Imm8(static_cast<u8>(index)), elem);
     default:
-        ASSERT_MSG(false, "Unreachable");
+        UNREACHABLE();
         return {};
     }
 }


### PR DESCRIPTION
We can just use the self-documenting assertion for indicating unreachable paths, instead of manually passing false and providing a message.