### PR TITLE
general: Mark hash functions as noexcept

### DIFF
--- a/src/backend/x64/a32_jitstate.cpp
+++ b/src/backend/x64/a32_jitstate.cpp
@@ -196,7 +196,7 @@ void A32JitState::SetFpscr(u32 FPSCR) {
     }
 }
 
-u64 A32JitState::GetUniqueHash() const {
+u64 A32JitState::GetUniqueHash() const noexcept {
     return CPSR_et | FPSCR_mode | (static_cast<u64>(Reg[15]) << 32);
 }
 

--- a/src/backend/x64/a32_jitstate.h
+++ b/src/backend/x64/a32_jitstate.h
@@ -76,7 +76,7 @@ struct A32JitState {
     u32 Fpscr() const;
     void SetFpscr(u32 FPSCR);
 
-    u64 GetUniqueHash() const;
+    u64 GetUniqueHash() const noexcept;
 };
 
 #ifdef _MSC_VER

--- a/src/backend/x64/a64_jitstate.cpp
+++ b/src/backend/x64/a64_jitstate.cpp
@@ -10,9 +10,9 @@
 
 namespace Dynarmic::BackendX64 {
 
-u64 A64JitState::GetUniqueHash() const {
-    u64 fpcr_u64 = static_cast<u64>(fpcr & A64::LocationDescriptor::FPCR_MASK) << 37;
-    u64 pc_u64 = pc & A64::LocationDescriptor::PC_MASK;
+u64 A64JitState::GetUniqueHash() const noexcept {
+    const u64 fpcr_u64 = static_cast<u64>(fpcr & A64::LocationDescriptor::FPCR_MASK) << 37;
+    const u64 pc_u64 = pc & A64::LocationDescriptor::PC_MASK;
     return pc_u64 | fpcr_u64;
 }
 

--- a/src/backend/x64/a64_jitstate.h
+++ b/src/backend/x64/a64_jitstate.h
@@ -81,7 +81,7 @@ struct A64JitState {
     void SetFpcr(u32 new_fpcr);
     void SetFpsr(u32 new_fpcr);
 
-    u64 GetUniqueHash() const;
+    u64 GetUniqueHash() const noexcept;
 };
 
 #ifdef _MSC_VER

--- a/src/frontend/A32/location_descriptor.h
+++ b/src/frontend/A32/location_descriptor.h
@@ -79,13 +79,13 @@ public:
         return LocationDescriptor(arm_pc, cpsr, A32::FPSCR{new_fpscr & FPSCR_MODE_MASK});
     }
 
-    u64 UniqueHash() const {
+    u64 UniqueHash() const noexcept {
         // This value MUST BE UNIQUE.
         // This calculation has to match up with EmitX64::EmitTerminalPopRSBHint
-        u64 pc_u64 = u64(arm_pc) << 32;
-        u64 fpscr_u64 = u64(fpscr.Value());
-        u64 t_u64 = cpsr.T() ? 1 : 0;
-        u64 e_u64 = cpsr.E() ? 2 : 0;
+        const u64 pc_u64 = u64(arm_pc) << 32;
+        const u64 fpscr_u64 = u64(fpscr.Value());
+        const u64 t_u64 = cpsr.T() ? 1 : 0;
+        const u64 e_u64 = cpsr.E() ? 2 : 0;
         return pc_u64 | fpscr_u64 | t_u64 | e_u64;
     }
 
@@ -112,13 +112,13 @@ std::ostream& operator<<(std::ostream& o, const LocationDescriptor& descriptor);
 namespace std {
 template <>
 struct less<Dynarmic::A32::LocationDescriptor> {
-    bool operator()(const Dynarmic::A32::LocationDescriptor& x, const Dynarmic::A32::LocationDescriptor& y) const {
+    bool operator()(const Dynarmic::A32::LocationDescriptor& x, const Dynarmic::A32::LocationDescriptor& y) const noexcept {
         return x.UniqueHash() < y.UniqueHash();
     }
 };
 template <>
 struct hash<Dynarmic::A32::LocationDescriptor> {
-    size_t operator()(const Dynarmic::A32::LocationDescriptor& x) const {
+    size_t operator()(const Dynarmic::A32::LocationDescriptor& x) const noexcept {
         return std::hash<u64>()(x.UniqueHash());
     }
 };

--- a/src/frontend/A64/location_descriptor.h
+++ b/src/frontend/A64/location_descriptor.h
@@ -51,10 +51,10 @@ public:
         return LocationDescriptor(static_cast<u64>(pc + amount), fpcr);
     }
 
-    u64 UniqueHash() const {
+    u64 UniqueHash() const noexcept {
         // This value MUST BE UNIQUE.
         // This calculation has to match up with EmitTerminalPopRSBHint
-        u64 fpcr_u64 = static_cast<u64>(fpcr.Value()) << 37;
+        const u64 fpcr_u64 = static_cast<u64>(fpcr.Value()) << 37;
         return pc | fpcr_u64;
     }
 
@@ -80,13 +80,13 @@ std::ostream& operator<<(std::ostream& o, const LocationDescriptor& descriptor);
 namespace std {
 template <>
 struct less<Dynarmic::A64::LocationDescriptor> {
-    bool operator()(const Dynarmic::A64::LocationDescriptor& x, const Dynarmic::A64::LocationDescriptor& y) const {
+    bool operator()(const Dynarmic::A64::LocationDescriptor& x, const Dynarmic::A64::LocationDescriptor& y) const noexcept {
         return x.UniqueHash() < y.UniqueHash();
     }
 };
 template <>
 struct hash<Dynarmic::A64::LocationDescriptor> {
-    size_t operator()(const Dynarmic::A64::LocationDescriptor& x) const {
+    size_t operator()(const Dynarmic::A64::LocationDescriptor& x) const noexcept {
         return std::hash<u64>()(x.UniqueHash());
     }
 };

--- a/src/frontend/ir/location_descriptor.h
+++ b/src/frontend/ir/location_descriptor.h
@@ -38,13 +38,13 @@ std::ostream& operator<<(std::ostream& o, const LocationDescriptor& descriptor);
 namespace std {
 template <>
 struct less<Dynarmic::IR::LocationDescriptor> {
-    bool operator()(const Dynarmic::IR::LocationDescriptor& x, const Dynarmic::IR::LocationDescriptor& y) const {
+    bool operator()(const Dynarmic::IR::LocationDescriptor& x, const Dynarmic::IR::LocationDescriptor& y) const noexcept {
         return x.Value() < y.Value();
     }
 };
 template <>
 struct hash<Dynarmic::IR::LocationDescriptor> {
-    size_t operator()(const Dynarmic::IR::LocationDescriptor& x) const {
+    size_t operator()(const Dynarmic::IR::LocationDescriptor& x) const noexcept {
         return std::hash<u64>()(x.Value());
     }
 };


### PR DESCRIPTION
Generally hash functions shouldn't throw exceptions. It's also a requirement for the standard library-provided hash functions to not throw exceptions.

An exception to this rule is made for user-defined specializations, however we can just be consistent with the standard library on this to allow these to potentially play nicer with it.