### PR TITLE
load_store_*: Make bracing consistent and variables const where applicable

### DIFF
--- a/src/frontend/A64/translate/impl/load_store_exclusive.cpp
+++ b/src/frontend/A64/translate/impl/load_store_exclusive.cpp
@@ -52,13 +52,13 @@ static bool ExclusiveSharedDecodeAndOperation(TranslatorVisitor& v, bool pair, s
         } else {
             data = v.X(elsize, Rt);
         }
-        IR::U32 status = v.ExclusiveMem(address, dbytes, acctype, data);
+        const IR::U32 status = v.ExclusiveMem(address, dbytes, acctype, data);
         v.X(32, *Rs, status);
         break;
     }
     case MemOp::LOAD: {
         v.ir.SetExclusive(address, dbytes);
-        IR::UAnyU128 data = v.Mem(address, dbytes, acctype);
+        const IR::UAnyU128 data = v.Mem(address, dbytes, acctype);
         if (pair && elsize == 64) {
             v.X(64, Rt, v.ir.VectorGetElement(64, data, 0));
             v.X(64, *Rt2, v.ir.VectorGetElement(64, data, 1));
@@ -164,12 +164,12 @@ static bool OrderedSharedDecodeAndOperation(TranslatorVisitor& v, size_t size, b
 
     switch (memop) {
     case MemOp::STORE: {
-        IR::UAny data = v.X(datasize, Rt);
+        const IR::UAny data = v.X(datasize, Rt);
         v.Mem(address, dbytes, acctype, data);
         break;
     }
     case MemOp::LOAD: {
-        IR::UAny data = v.Mem(address, dbytes, acctype);
+        const IR::UAny data = v.Mem(address, dbytes, acctype);
         v.X(regsize, Rt, v.ZeroExtend(data, regsize));
         break;
     }

--- a/src/frontend/A64/translate/impl/load_store_multiple_structures.cpp
+++ b/src/frontend/A64/translate/impl/load_store_multiple_structures.cpp
@@ -57,11 +57,12 @@ static bool SharedDecodeAndOperation(TranslatorVisitor& v, bool wback, MemOp mem
     }
 
     IR::U64 address;
-    if (Rn == Reg::SP)
+    if (Rn == Reg::SP) {
         // TODO: Check SP Alignment
         address = v.SP(64);
-    else
+    } else {
         address = v.X(64, Rn);
+    }
 
     IR::U64 offs = v.ir.Imm64(0);
     if (selem == 1) {
@@ -94,12 +95,15 @@ static bool SharedDecodeAndOperation(TranslatorVisitor& v, bool wback, MemOp mem
     }
 
     if (wback) {
-        if (*Rm != Reg::SP)
+        if (*Rm != Reg::SP) {
             offs = v.X(64, *Rm);
-        if (Rn == Reg::SP)
+        }
+
+        if (Rn == Reg::SP) {
             v.SP(64, v.ir.Add(address, offs));
-        else
+        } else {
             v.X(64, Rn, v.ir.Add(address, offs));
+        }
     }
 
     return true;

--- a/src/frontend/A64/translate/impl/load_store_register_register_offset.cpp
+++ b/src/frontend/A64/translate/impl/load_store_register_register_offset.cpp
@@ -51,12 +51,12 @@ static bool RegSharedDecodeAndOperation(TranslatorVisitor& v, size_t scale, u8 s
 
     switch (memop) {
     case MemOp::STORE: {
-        IR::UAny data = v.X(datasize, Rt);
+        const IR::UAny data = v.X(datasize, Rt);
         v.Mem(address, datasize / 8, acctype, data);
         break;
     }
     case MemOp::LOAD: {
-        IR::UAny data = v.Mem(address, datasize / 8, acctype);
+        const IR::UAny data = v.Mem(address, datasize / 8, acctype);
         if (signed_) {
             v.X(regsize, Rt, v.SignExtend(data, regsize));
         } else {

--- a/src/frontend/A64/translate/impl/load_store_single_structure.cpp
+++ b/src/frontend/A64/translate/impl/load_store_single_structure.cpp
@@ -54,11 +54,12 @@ static bool SharedDecodeAndOperation(TranslatorVisitor& v, bool wback, MemOp mem
     const size_t ebytes = esize / 8;
 
     IR::U64 address;
-    if (Rn == Reg::SP)
+    if (Rn == Reg::SP) {
         // TODO: Check SP Alignment
         address = v.SP(64);
-    else
+    } else {
         address = v.X(64, Rn);
+    }
 
     IR::U64 offs = v.ir.Imm64(0);
     if (replicate) {
@@ -89,12 +90,15 @@ static bool SharedDecodeAndOperation(TranslatorVisitor& v, bool wback, MemOp mem
     }
 
     if (wback) {
-        if (*Rm != Reg::SP)
+        if (*Rm != Reg::SP) {
             offs = v.X(64, *Rm);
-        if (Rn == Reg::SP)
+        }
+
+        if (Rn == Reg::SP) {
             v.SP(64, v.ir.Add(address, offs));
-        else
+        } else {
             v.X(64, Rn, v.ir.Add(address, offs));
+        }
     }
 
     return true;


### PR DESCRIPTION
Makes bracing consistent, and variables const where applicable to be consistent with the rest of the codebase.

In most bracing cases, they'd need to be added to conditionals that would involve checking stack pointer alignment in the future anyways.