### PR TITLE
ir/basic_block: Forward declare headers where applicable

### DIFF
--- a/src/frontend/ir/basic_block.cpp
+++ b/src/frontend/ir/basic_block.cpp
@@ -13,15 +13,17 @@
 #include <fmt/ostream.h>
 
 #include "common/assert.h"
+#include "common/memory_pool.h"
 #include "frontend/A32/types.h"
 #include "frontend/A64/types.h"
 #include "frontend/ir/basic_block.h"
+#include "frontend/ir/cond.h"
 #include "frontend/ir/opcodes.h"
 
 namespace Dynarmic::IR {
 
 Block::Block(const LocationDescriptor& location)
-    : location{location}, end_location{location},
+    : location{location}, end_location{location}, cond{Cond::AL},
       instruction_alloc_pool{std::make_unique<Common::Pool>(sizeof(Inst), 4096)} {}
 
 Block::~Block() = default;

--- a/src/frontend/ir/basic_block.cpp
+++ b/src/frontend/ir/basic_block.cpp
@@ -20,6 +20,16 @@
 
 namespace Dynarmic::IR {
 
+Block::Block(const LocationDescriptor& location)
+    : location{location}, end_location{location},
+      instruction_alloc_pool{std::make_unique<Common::Pool>(sizeof(Inst), 4096)} {}
+
+Block::~Block() = default;
+
+Block::Block(Block&&) = default;
+
+Block& Block::operator=(Block&&) = default;
+
 void Block::AppendNewInst(Opcode opcode, std::initializer_list<IR::Value> args) {
     PrependNewInst(end(), opcode, args);
 }

--- a/src/frontend/ir/basic_block.h
+++ b/src/frontend/ir/basic_block.h
@@ -13,15 +13,18 @@
 
 #include "common/common_types.h"
 #include "common/intrusive_list.h"
-#include "common/memory_pool.h"
-#include "frontend/ir/cond.h"
 #include "frontend/ir/location_descriptor.h"
 #include "frontend/ir/microinstruction.h"
 #include "frontend/ir/terminal.h"
 #include "frontend/ir/value.h"
 
+namespace Dynarmic::Common {
+class Pool;
+}
+
 namespace Dynarmic::IR {
 
+enum class Cond;
 enum class Opcode;
 
 /**
@@ -142,7 +145,7 @@ private:
     /// Description of the end location of this block
     LocationDescriptor end_location;
     /// Conditional to pass in order to execute this block
-    Cond cond = Cond::AL;
+    Cond cond;
     /// Block to execute next if `cond` did not pass.
     std::optional<LocationDescriptor> cond_failed = {};
     /// Number of cycles this block takes to execute if the conditional fails.

--- a/src/frontend/ir/basic_block.h
+++ b/src/frontend/ir/basic_block.h
@@ -39,8 +39,14 @@ public:
     using reverse_iterator       = InstructionList::reverse_iterator;
     using const_reverse_iterator = InstructionList::const_reverse_iterator;
 
-    explicit Block(const LocationDescriptor& location)
-        : location(location), end_location(location) {}
+    explicit Block(const LocationDescriptor& location);
+    ~Block();
+
+    Block(const Block&) = delete;
+    Block& operator=(const Block&) = delete;
+
+    Block(Block&&);
+    Block& operator=(Block&&);
 
     bool                   empty()   const { return instructions.empty();   }
     size_type              size()    const { return instructions.size();    }
@@ -145,7 +151,7 @@ private:
     /// List of instructions in this block.
     InstructionList instructions;
     /// Memory pool for instruction list
-    std::unique_ptr<Common::Pool> instruction_alloc_pool = std::make_unique<Common::Pool>(sizeof(Inst), 4096);
+    std::unique_ptr<Common::Pool> instruction_alloc_pool;
     /// Terminal instruction of this block.
     Terminal terminal = Term::Invalid{};
 


### PR DESCRIPTION
Avoids inclusions where applicable. Notably, doing so allows making changes to the memory pool interface (should it be necessary), without having it ripple across the whole IR emitter framework.