### PR TITLE
frontend: Move imm.h to the top-level directory of the frontends

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,6 +77,7 @@ add_library(dynarmic
     common/u128.cpp
     common/u128.h
     common/variant_util.h
+    frontend/imm.h
     frontend/A32/decoder/arm.h
     frontend/A32/decoder/arm.inc
     frontend/A32/decoder/thumb16.h
@@ -118,7 +119,6 @@ add_library(dynarmic
     frontend/A32/types.h
     frontend/A64/decoder/a64.h
     frontend/A64/decoder/a64.inc
-    frontend/A64/imm.h
     frontend/A64/ir_emitter.cpp
     frontend/A64/ir_emitter.h
     frontend/A64/location_descriptor.cpp

--- a/src/frontend/A64/translate/impl/impl.h
+++ b/src/frontend/A64/translate/impl/impl.h
@@ -8,7 +8,7 @@
 
 #include <optional>
 
-#include "frontend/A64/imm.h"
+#include "frontend/imm.h"
 #include "frontend/A64/ir_emitter.h"
 #include "frontend/A64/location_descriptor.h"
 #include "frontend/A64/translate/translate.h"

--- a/src/frontend/imm.h
+++ b/src/frontend/imm.h
@@ -11,10 +11,10 @@
 #include "common/common_types.h"
 #include "common/math_util.h"
 
-namespace Dynarmic::A64 {
+namespace Dynarmic {
 
 /**
- * Imm represents an immediate value in an AArch64 instruction.
+ * Imm represents an immediate value in an AArch32/AArch64 instruction.
  * Imm is used during translation as a typesafe way of passing around immediates of fixed sizes.
  */
 template <size_t bit_size_>
@@ -158,4 +158,4 @@ auto concatenate(Imm<first_bit_size> first, Imm<rest_bit_sizes> ...rest) {
     }
 }
 
-} // namespace Dynarmic::A64
+} // namespace Dynarmic


### PR DESCRIPTION
Preparation to utilize the immediate type within the A32 backend as well, which will allow eliminating numerous type aliases like Imm4, Imm5, etc.