### PR TITLE
frontend/ir/ir_emitter: Remove unnecessary logical shift overloads

### DIFF
--- a/src/frontend/ir/ir_emitter.cpp
+++ b/src/frontend/ir/ir_emitter.cpp
@@ -153,22 +153,6 @@ ResultAndCarry<U32> IREmitter::RotateRightExtended(const U32& value_in, const U1
     return {result, carry_out};
 }
 
-U32 IREmitter::LogicalShiftLeft(const U32& value_in, const U8& shift_amount) {
-    return Inst<U32>(Opcode::LogicalShiftLeft32, value_in, shift_amount, Imm1(0));
-}
-
-U64 IREmitter::LogicalShiftLeft(const U64& value_in, const U8& shift_amount) {
-    return Inst<U64>(Opcode::LogicalShiftLeft64, value_in, shift_amount);
-}
-
-U32 IREmitter::LogicalShiftRight(const U32& value_in, const U8& shift_amount) {
-    return Inst<U32>(Opcode::LogicalShiftRight32, value_in, shift_amount, Imm1(0));
-}
-
-U64 IREmitter::LogicalShiftRight(const U64& value_in, const U8& shift_amount) {
-    return Inst<U64>(Opcode::LogicalShiftRight64, value_in, shift_amount);
-}
-
 U32U64 IREmitter::LogicalShiftLeft(const U32U64& value_in, const U8& shift_amount) {
     if (value_in.GetType() == Type::U32) {
         return Inst<U32>(Opcode::LogicalShiftLeft32, value_in, shift_amount, Imm1(0));

--- a/src/frontend/ir/ir_emitter.h
+++ b/src/frontend/ir/ir_emitter.h
@@ -100,11 +100,7 @@ public:
     ResultAndCarry<U32> LogicalShiftRight(const U32& value_in, const U8& shift_amount, const U1& carry_in);
     ResultAndCarry<U32> ArithmeticShiftRight(const U32& value_in, const U8& shift_amount, const U1& carry_in);
     ResultAndCarry<U32> RotateRight(const U32& value_in, const U8& shift_amount, const U1& carry_in);
-    U32 LogicalShiftLeft(const U32& value_in, const U8& shift_amount);
-    U64 LogicalShiftLeft(const U64& value_in, const U8& shift_amount);
     U32U64 LogicalShiftLeft(const U32U64& value_in, const U8& shift_amount);
-    U32 LogicalShiftRight(const U32& value_in, const U8& shift_amount);
-    U64 LogicalShiftRight(const U64& value_in, const U8& shift_amount);
     U32U64 LogicalShiftRight(const U32U64& value_in, const U8& shift_amount);
     U32U64 ArithmeticShiftRight(const U32U64& value_in, const U8& shift_amount);
     U32U64 RotateRight(const U32U64& value_in, const U8& shift_amount);


### PR DESCRIPTION
These aren't necessary anymore, now that the U32U64 overload exists.