### PR TITLE
A32: Implement Thumb-1 hint instructions

### DIFF
--- a/include/dynarmic/A32/config.h
+++ b/include/dynarmic/A32/config.h
@@ -26,6 +26,8 @@ enum class Exception {
     UnpredictableInstruction,
     /// A SEV instruction was executed. The event register of all PEs should be set.
     SendEvent,
+    /// A SEVL instruction was executed. The event register of the current PE should be set.
+    SendEventLocal,
     /// A WFI instruction was executed. You may now enter a low-power state.
     WaitForInterrupt,
     /// A WFE instruction was executed. You may now enter a low-power state if the event register is clear.

--- a/include/dynarmic/A64/config.h
+++ b/include/dynarmic/A64/config.h
@@ -34,7 +34,7 @@ enum class Exception {
     WaitForEvent,
     /// A SEV instruction was executed. The event register of all PEs should be set.
     SendEvent,
-    /// A SEV instruction was executed. The event register of the current PE should be set.
+    /// A SEVL instruction was executed. The event register of the current PE should be set.
     SendEventLocal,
     /// A YIELD instruction was executed.
     Yield,

--- a/src/frontend/A32/decoder/arm.inc
+++ b/src/frontend/A32/decoder/arm.inc
@@ -97,6 +97,7 @@ INST(arm_UXTAH,         "UXTAH",               "cccc01101111nnnnddddrr000111mmmm
 INST(arm_PLD_imm,       "PLD (imm)",           "11110101uz01nnnn1111iiiiiiiiiiii") // v5E for PLD; v7 for PLDW
 INST(arm_PLD_reg,       "PLD (reg)",           "11110111uz01nnnn1111iiiiitt0mmmm") // v5E for PLD; v7 for PLDW
 INST(arm_SEV,           "SEV",                 "----0011001000001111000000000100") // v6K
+INST(arm_SEVL,          "SEVL",                "----0011001000001111000000000101") // v8
 INST(arm_WFE,           "WFE",                 "----0011001000001111000000000010") // v6K
 INST(arm_WFI,           "WFI",                 "----0011001000001111000000000011") // v6K
 INST(arm_YIELD,         "YIELD",               "----0011001000001111000000000001") // v6K

--- a/src/frontend/A32/decoder/thumb16.h
+++ b/src/frontend/A32/decoder/thumb16.h
@@ -90,6 +90,7 @@ std::optional<std::reference_wrapper<const Thumb16Matcher<V>>> DecodeThumb16(u16
         // Hint instructions
         INST(&V::thumb16_NOP,            "NOP",                      "1011111100000000"), // v6T2
         INST(&V::thumb16_SEV,            "SEV",                      "1011111101000000"), // v7
+        INST(&V::thumb16_SEVL,           "SEVL",                     "1011111101010000"), // v8
         INST(&V::thumb16_WFE,            "WFE",                      "1011111100100000"), // v7
         INST(&V::thumb16_WFI,            "WFI",                      "1011111100110000"), // v7
         INST(&V::thumb16_YIELD,          "YIELD",                    "1011111100010000"), // v7

--- a/src/frontend/A32/decoder/thumb16.h
+++ b/src/frontend/A32/decoder/thumb16.h
@@ -90,6 +90,7 @@ std::optional<std::reference_wrapper<const Thumb16Matcher<V>>> DecodeThumb16(u16
         // Hint instructions
         INST(&V::thumb16_NOP,            "NOP",                      "1011111100000000"), // v6T2
         INST(&V::thumb16_SEV,            "SEV",                      "1011111101000000"), // v7
+        INST(&V::thumb16_WFE,            "WFE",                      "1011111100100000"), // v7
 
         // Miscellaneous 16-bit instructions
         INST(&V::thumb16_SXTH,           "SXTH",                     "1011001000mmmddd"), // v6

--- a/src/frontend/A32/decoder/thumb16.h
+++ b/src/frontend/A32/decoder/thumb16.h
@@ -89,6 +89,7 @@ std::optional<std::reference_wrapper<const Thumb16Matcher<V>>> DecodeThumb16(u16
 
         // Hint instructions
         INST(&V::thumb16_NOP,            "NOP",                      "1011111100000000"), // v6T2
+        INST(&V::thumb16_SEV,            "SEV",                      "1011111101000000"), // v7
 
         // Miscellaneous 16-bit instructions
         INST(&V::thumb16_SXTH,           "SXTH",                     "1011001000mmmddd"), // v6

--- a/src/frontend/A32/decoder/thumb16.h
+++ b/src/frontend/A32/decoder/thumb16.h
@@ -92,6 +92,7 @@ std::optional<std::reference_wrapper<const Thumb16Matcher<V>>> DecodeThumb16(u16
         INST(&V::thumb16_SEV,            "SEV",                      "1011111101000000"), // v7
         INST(&V::thumb16_WFE,            "WFE",                      "1011111100100000"), // v7
         INST(&V::thumb16_WFI,            "WFI",                      "1011111100110000"), // v7
+        INST(&V::thumb16_YIELD,          "YIELD",                    "1011111100010000"), // v7
 
         // Miscellaneous 16-bit instructions
         INST(&V::thumb16_SXTH,           "SXTH",                     "1011001000mmmddd"), // v6

--- a/src/frontend/A32/decoder/thumb16.h
+++ b/src/frontend/A32/decoder/thumb16.h
@@ -91,6 +91,7 @@ std::optional<std::reference_wrapper<const Thumb16Matcher<V>>> DecodeThumb16(u16
         INST(&V::thumb16_NOP,            "NOP",                      "1011111100000000"), // v6T2
         INST(&V::thumb16_SEV,            "SEV",                      "1011111101000000"), // v7
         INST(&V::thumb16_WFE,            "WFE",                      "1011111100100000"), // v7
+        INST(&V::thumb16_WFI,            "WFI",                      "1011111100110000"), // v7
 
         // Miscellaneous 16-bit instructions
         INST(&V::thumb16_SXTH,           "SXTH",                     "1011001000mmmddd"), // v6

--- a/src/frontend/A32/decoder/thumb16.h
+++ b/src/frontend/A32/decoder/thumb16.h
@@ -87,6 +87,9 @@ std::optional<std::reference_wrapper<const Thumb16Matcher<V>>> DecodeThumb16(u16
         INST(&V::thumb16_ADD_sp_t2,      "ADD (SP plus imm, T2)",    "101100000vvvvvvv"), // v4T
         INST(&V::thumb16_SUB_sp,         "SUB (SP minus imm)",       "101100001vvvvvvv"), // v4T
 
+        // Hint instructions
+        INST(&V::thumb16_NOP,            "NOP",                      "1011111100000000"), // v6T2
+
         // Miscellaneous 16-bit instructions
         INST(&V::thumb16_SXTH,           "SXTH",                     "1011001000mmmddd"), // v6
         INST(&V::thumb16_SXTB,           "SXTB",                     "1011001001mmmddd"), // v6

--- a/src/frontend/A32/decoder/thumb32.h
+++ b/src/frontend/A32/decoder/thumb32.h
@@ -127,6 +127,7 @@ std::optional<std::reference_wrapper<const Thumb32Matcher<V>>> DecodeThumb32(u32
         //INST(&V::thumb32_WFE,            "WFE",                      "111100111010----10-0-00000000010"),
         //INST(&V::thumb32_WFI,            "WFI",                      "111100111010----10-0-00000000011"),
         //INST(&V::thumb32_SEV,            "SEV",                      "111100111010----10-0-00000000100"),
+        //INST(&V::thumb32_SEVL,           "SEVL",                     "111100111010----10-0-00000000101"),
         //INST(&V::thumb32_DBG,            "DBG",                      "111100111010----10-0-0001111----"),
         //INST(&V::thumb32_CPS,            "CPS",                      "111100111010----10-0------------"),
 

--- a/src/frontend/A32/disassembler/disassembler_arm.cpp
+++ b/src/frontend/A32/disassembler/disassembler_arm.cpp
@@ -451,6 +451,9 @@ public:
     std::string arm_SEV() {
         return "sev";
     }
+    std::string arm_SEVL() {
+        return "sevl";
+    }
     std::string arm_WFE() {
         return "wfe";
     }

--- a/src/frontend/A32/disassembler/disassembler_thumb.cpp
+++ b/src/frontend/A32/disassembler/disassembler_thumb.cpp
@@ -262,6 +262,10 @@ public:
         return "wfi";
     }
 
+    std::string thumb16_YIELD() {
+        return "yield";
+    }
+
     std::string thumb16_SXTH(Reg m, Reg d) {
         return fmt::format("sxth {}, {}", d, m);
     }

--- a/src/frontend/A32/disassembler/disassembler_thumb.cpp
+++ b/src/frontend/A32/disassembler/disassembler_thumb.cpp
@@ -250,6 +250,10 @@ public:
         return "nop";
     }
 
+    std::string thumb16_SEV() {
+        return "sev";
+    }
+
     std::string thumb16_SXTH(Reg m, Reg d) {
         return fmt::format("sxth {}, {}", d, m);
     }

--- a/src/frontend/A32/disassembler/disassembler_thumb.cpp
+++ b/src/frontend/A32/disassembler/disassembler_thumb.cpp
@@ -254,6 +254,10 @@ public:
         return "sev";
     }
 
+    std::string thumb16_WFE() {
+        return "wfe";
+    }
+
     std::string thumb16_SXTH(Reg m, Reg d) {
         return fmt::format("sxth {}, {}", d, m);
     }

--- a/src/frontend/A32/disassembler/disassembler_thumb.cpp
+++ b/src/frontend/A32/disassembler/disassembler_thumb.cpp
@@ -254,6 +254,10 @@ public:
         return "sev";
     }
 
+    std::string thumb16_SEVL() {
+        return "sevl";
+    }
+
     std::string thumb16_WFE() {
         return "wfe";
     }

--- a/src/frontend/A32/disassembler/disassembler_thumb.cpp
+++ b/src/frontend/A32/disassembler/disassembler_thumb.cpp
@@ -246,6 +246,10 @@ public:
         return fmt::format("sub sp, sp, #{}", imm32);
     }
 
+    std::string thumb16_NOP() {
+        return "nop";
+    }
+
     std::string thumb16_SXTH(Reg m, Reg d) {
         return fmt::format("sxth {}, {}", d, m);
     }

--- a/src/frontend/A32/disassembler/disassembler_thumb.cpp
+++ b/src/frontend/A32/disassembler/disassembler_thumb.cpp
@@ -258,6 +258,10 @@ public:
         return "wfe";
     }
 
+    std::string thumb16_WFI() {
+        return "wfi";
+    }
+
     std::string thumb16_SXTH(Reg m, Reg d) {
         return fmt::format("sxth {}, {}", d, m);
     }

--- a/src/frontend/A32/translate/translate_arm/hint.cpp
+++ b/src/frontend/A32/translate/translate_arm/hint.cpp
@@ -33,6 +33,10 @@ bool ArmTranslatorVisitor::arm_SEV() {
     return RaiseException(Exception::SendEvent);
 }
 
+bool ArmTranslatorVisitor::arm_SEVL() {
+    return RaiseException(Exception::SendEventLocal);
+}
+
 bool ArmTranslatorVisitor::arm_WFE() {
     return RaiseException(Exception::WaitForEvent);
 }

--- a/src/frontend/A32/translate/translate_arm/translate_arm.h
+++ b/src/frontend/A32/translate/translate_arm/translate_arm.h
@@ -167,6 +167,7 @@ struct ArmTranslatorVisitor final {
     bool arm_PLD_imm(bool add, bool R, Reg n, Imm<12> imm12);
     bool arm_PLD_reg(bool add, bool R, Reg n, Imm<5> imm5, ShiftType shift, Reg m);
     bool arm_SEV();
+    bool arm_SEVL();
     bool arm_WFE();
     bool arm_WFI();
     bool arm_YIELD();

--- a/src/frontend/A32/translate/translate_thumb.cpp
+++ b/src/frontend/A32/translate/translate_thumb.cpp
@@ -684,6 +684,11 @@ struct ThumbTranslatorVisitor final {
         return RaiseException(Exception::SendEvent);
     }
 
+    // WFE<c>
+    bool thumb16_WFE() {
+        return RaiseException(Exception::WaitForEvent);
+    }
+
     // SXTH <Rd>, <Rm>
     // Rd cannot encode R15.
     bool thumb16_SXTH(Reg m, Reg d) {

--- a/src/frontend/A32/translate/translate_thumb.cpp
+++ b/src/frontend/A32/translate/translate_thumb.cpp
@@ -679,6 +679,11 @@ struct ThumbTranslatorVisitor final {
         return true;
     }
 
+    // SEV<c>
+    bool thumb16_SEV() {
+        return RaiseException(Exception::SendEvent);
+    }
+
     // SXTH <Rd>, <Rm>
     // Rd cannot encode R15.
     bool thumb16_SXTH(Reg m, Reg d) {

--- a/src/frontend/A32/translate/translate_thumb.cpp
+++ b/src/frontend/A32/translate/translate_thumb.cpp
@@ -41,6 +41,13 @@ struct ThumbTranslatorVisitor final {
         return false;
     }
 
+    bool RaiseException(Exception exception) {
+        ir.BranchWritePC(ir.Imm32(ir.current_location.PC() + 2));
+        ir.ExceptionRaised(exception);
+        ir.SetTerm(IR::Term::CheckHalt{IR::Term::ReturnToDispatch{}});
+        return false;
+    }
+
     // LSLS <Rd>, <Rm>, #<imm5>
     bool thumb16_LSL_imm(Imm<5> imm5, Reg m, Reg d) {
         const u8 shift_n = imm5.ZeroExtend<u8>();

--- a/src/frontend/A32/translate/translate_thumb.cpp
+++ b/src/frontend/A32/translate/translate_thumb.cpp
@@ -694,6 +694,11 @@ struct ThumbTranslatorVisitor final {
         return RaiseException(Exception::WaitForInterrupt);
     }
 
+    // YIELD<c>
+    bool thumb16_YIELD() {
+        return RaiseException(Exception::Yield);
+    }
+
     // SXTH <Rd>, <Rm>
     // Rd cannot encode R15.
     bool thumb16_SXTH(Reg m, Reg d) {

--- a/src/frontend/A32/translate/translate_thumb.cpp
+++ b/src/frontend/A32/translate/translate_thumb.cpp
@@ -684,6 +684,11 @@ struct ThumbTranslatorVisitor final {
         return RaiseException(Exception::SendEvent);
     }
 
+    // SEVL<c>
+    bool thumb16_SEVL() {
+        return RaiseException(Exception::SendEventLocal);
+    }
+
     // WFE<c>
     bool thumb16_WFE() {
         return RaiseException(Exception::WaitForEvent);

--- a/src/frontend/A32/translate/translate_thumb.cpp
+++ b/src/frontend/A32/translate/translate_thumb.cpp
@@ -667,6 +667,11 @@ struct ThumbTranslatorVisitor final {
         return true;
     }
 
+    // NOP<c>
+    bool thumb16_NOP() {
+        return true;
+    }
+
     // SXTH <Rd>, <Rm>
     // Rd cannot encode R15.
     bool thumb16_SXTH(Reg m, Reg d) {

--- a/src/frontend/A32/translate/translate_thumb.cpp
+++ b/src/frontend/A32/translate/translate_thumb.cpp
@@ -689,6 +689,11 @@ struct ThumbTranslatorVisitor final {
         return RaiseException(Exception::WaitForEvent);
     }
 
+    // WFI<c>
+    bool thumb16_WFI() {
+        return RaiseException(Exception::WaitForInterrupt);
+    }
+
     // SXTH <Rd>, <Rm>
     // Rd cannot encode R15.
     bool thumb16_SXTH(Reg m, Reg d) {


### PR DESCRIPTION
Implements `NOP`, `SEV`, `SEVL`, `WFE`, `WFI`, and `YIELD` variants for Thumb-1. While we're in the same area, this also implements the ARM-mode variant of `SEVL`, given it's just as easy to implement as the Thumb-1 version.