### PR TITLE
A32/coprocessor: Remove boost from public interface

### DIFF
--- a/.travis/build-x86_64-macos/build.sh
+++ b/.travis/build-x86_64-macos/build.sh
@@ -4,7 +4,7 @@ set -e
 set -x
 set -o pipefail
 
-export MACOSX_DEPLOYMENT_TARGET=10.12
+export MACOSX_DEPLOYMENT_TARGET=10.14
 
 mkdir build && cd build
 cmake .. -GXcode -DBoost_INCLUDE_DIRS=${PWD}/../externals/ext-boost -DDYNARMIC_TESTS=0

--- a/include/dynarmic/A32/coprocessor.h
+++ b/include/dynarmic/A32/coprocessor.h
@@ -8,8 +8,7 @@
 
 #include <cstdint>
 #include <optional>
-
-#include <boost/variant.hpp>
+#include <variant>
 
 #include <dynarmic/A32/coprocessor_util.h>
 
@@ -36,18 +35,18 @@ public:
     };
 
     /**
-     * boost::blank: coprocessor exception will be compiled
+     * std::monostate: coprocessor exception will be compiled
      * Callback: a call to the Callback will be compiled
      * std::uint32_t*: a write/read to that memory address will be compiled
      */
-    using CallbackOrAccessOneWord = boost::variant<boost::blank, Callback, std::uint32_t*>;
+    using CallbackOrAccessOneWord = std::variant<std::monostate, Callback, std::uint32_t*>;
 
     /**
-     * boost::blank: coprocessor exception will be compiled
+     * std::monostate: coprocessor exception will be compiled
      * Callback: a call to the Callback will be compiled
      * std::array<std::uint32_t*, 2>: a write/read to those memory addresses will be compiled
      */
-    using CallbackOrAccessTwoWords = boost::variant<boost::blank, Callback, std::array<std::uint32_t*, 2>>;
+    using CallbackOrAccessTwoWords = std::variant<std::monostate, Callback, std::array<std::uint32_t*, 2>>;
 
     /**
      * Called when compiling CDP or CDP2 for this coprocessor.
@@ -58,7 +57,7 @@ public:
 
     /**
      * Called when compiling MCR or MCR2 for this coprocessor.
-     * A return value of boost::blank will cause a coprocessor exception to be compiled.
+     * A return value of std::monostate will cause a coprocessor exception to be compiled.
      * arg0 of the callback will contain the word sent to the coprocessor.
      * arg1 and return value of the callback are ignored.
      */
@@ -74,7 +73,7 @@ public:
 
     /**
      * Called when compiling MRC or MRC2 for this coprocessor.
-     * A return value of boost::blank will cause a coprocessor exception to be compiled.
+     * A return value of std::monostate will cause a coprocessor exception to be compiled.
      * The return value of the callback should contain word from coprocessor.
      * The low word of the return value will be stored in Rt.
      * arg0 and arg1 of the callback are ignored.
@@ -83,7 +82,7 @@ public:
 
     /**
      * Called when compiling MRRC or MRRC2 for this coprocessor.
-     * A return value of boost::blank will cause a coprocessor exception to be compiled.
+     * A return value of std::monostate will cause a coprocessor exception to be compiled.
      * The return value of the callback should contain words from coprocessor.
      * The low word of the return value will be stored in Rt.
      * The high word of the return value will be stored in Rt2.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -279,9 +279,8 @@ target_include_directories(dynarmic
                            PRIVATE .)
 target_compile_options(dynarmic PRIVATE ${DYNARMIC_CXX_FLAGS})
 target_link_libraries(dynarmic
-    PUBLIC
-        boost
     PRIVATE
+        boost
         fmt::fmt
         xbyak
         $<$<BOOL:DYNARMIC_USE_LLVM>:${llvm_libs}>

--- a/src/backend/x64/a32_emit_x64.cpp
+++ b/src/backend/x64/a32_emit_x64.cpp
@@ -1018,15 +1018,15 @@ void A32EmitX64::EmitA32CoprocSendOneWord(A32EmitContext& ctx, IR::Inst* inst) {
     }
 
     const auto action = coproc->CompileSendOneWord(two, opc1, CRn, CRm, opc2);
-    switch (action.which()) {
+    switch (action.index()) {
     case 0:
         EmitCoprocessorException();
         return;
     case 1:
-        CallCoprocCallback(code, ctx.reg_alloc, jit_interface, boost::get<A32::Coprocessor::Callback>(action), nullptr, args[1]);
+        CallCoprocCallback(code, ctx.reg_alloc, jit_interface, std::get<A32::Coprocessor::Callback>(action), nullptr, args[1]);
         return;
     case 2: {
-        const u32* const destination_ptr = boost::get<u32*>(action);
+        const u32* const destination_ptr = std::get<u32*>(action);
 
         const Xbyak::Reg32 reg_word = ctx.reg_alloc.UseGpr(args[1]).cvt32();
         const Xbyak::Reg64 reg_destination_addr = ctx.reg_alloc.ScratchGpr();
@@ -1057,15 +1057,15 @@ void A32EmitX64::EmitA32CoprocSendTwoWords(A32EmitContext& ctx, IR::Inst* inst) 
     }
 
     const auto action = coproc->CompileSendTwoWords(two, opc, CRm);
-    switch (action.which()) {
+    switch (action.index()) {
     case 0:
         EmitCoprocessorException();
         return;
     case 1:
-        CallCoprocCallback(code, ctx.reg_alloc, jit_interface, boost::get<A32::Coprocessor::Callback>(action), nullptr, args[1], args[2]);
+        CallCoprocCallback(code, ctx.reg_alloc, jit_interface, std::get<A32::Coprocessor::Callback>(action), nullptr, args[1], args[2]);
         return;
     case 2: {
-        const auto destination_ptrs = boost::get<std::array<u32*, 2>>(action);
+        const auto destination_ptrs = std::get<std::array<u32*, 2>>(action);
 
         const Xbyak::Reg32 reg_word1 = ctx.reg_alloc.UseGpr(args[1]).cvt32();
         const Xbyak::Reg32 reg_word2 = ctx.reg_alloc.UseGpr(args[2]).cvt32();
@@ -1100,15 +1100,15 @@ void A32EmitX64::EmitA32CoprocGetOneWord(A32EmitContext& ctx, IR::Inst* inst) {
     }
 
     const auto action = coproc->CompileGetOneWord(two, opc1, CRn, CRm, opc2);
-    switch (action.which()) {
+    switch (action.index()) {
     case 0:
         EmitCoprocessorException();
         return;
     case 1:
-        CallCoprocCallback(code, ctx.reg_alloc, jit_interface, boost::get<A32::Coprocessor::Callback>(action), inst);
+        CallCoprocCallback(code, ctx.reg_alloc, jit_interface, std::get<A32::Coprocessor::Callback>(action), inst);
         return;
     case 2: {
-        const u32* const source_ptr = boost::get<u32*>(action);
+        const u32* const source_ptr = std::get<u32*>(action);
 
         const Xbyak::Reg32 reg_word = ctx.reg_alloc.ScratchGpr().cvt32();
         const Xbyak::Reg64 reg_source_addr = ctx.reg_alloc.ScratchGpr();
@@ -1139,15 +1139,15 @@ void A32EmitX64::EmitA32CoprocGetTwoWords(A32EmitContext& ctx, IR::Inst* inst) {
     }
 
     auto action = coproc->CompileGetTwoWords(two, opc, CRm);
-    switch (action.which()) {
+    switch (action.index()) {
     case 0:
         EmitCoprocessorException();
         return;
     case 1:
-        CallCoprocCallback(code, ctx.reg_alloc, jit_interface, boost::get<A32::Coprocessor::Callback>(action), inst);
+        CallCoprocCallback(code, ctx.reg_alloc, jit_interface, std::get<A32::Coprocessor::Callback>(action), inst);
         return;
     case 2: {
-        const auto source_ptrs = boost::get<std::array<u32*, 2>>(action);
+        const auto source_ptrs = std::get<std::array<u32*, 2>>(action);
 
         const Xbyak::Reg64 reg_result = ctx.reg_alloc.ScratchGpr();
         const Xbyak::Reg64 reg_destination_addr = ctx.reg_alloc.ScratchGpr();


### PR DESCRIPTION
Removes a boost header from the public includes in favor of using the standard-provided std::variant. Given we use std::optional in the header already, we can transition over to the std::variant from boost::variant.

With this removal, this makes all of our dependencies internal to the library itself.