### PR TITLE
A32/location_descriptor: Add AHP bit to the FPSCR mask

### DIFF
--- a/src/backend/x64/a32_jitstate.cpp
+++ b/src/backend/x64/a32_jitstate.cpp
@@ -135,17 +135,18 @@ void A32JitState::ResetRSB() {
  *
  * SSE MXCSR mode bits
  * -------------------
- * FZ   bit 15  Flush To Zero
- * DAZ  bit 6   Denormals Are Zero
+ * FZ   bit 15      Flush To Zero
+ * DAZ  bit 6       Denormals Are Zero
  * RN   bits 13-14  Round to {0 = Nearest, 1 = Negative, 2 = Positive, 3 = Zero}
  *
  * VFP FPSCR mode bits
  * -------------------
- * DN   bit 25  Default NaN
- * FZ   bit 24  Flush to Zero
+ * AHP      bit 26      Alternate half-precision
+ * DN       bit 25      Default NaN
+ * FZ       bit 24      Flush to Zero
  * RMode    bits 22-23  Round to {0 = Nearest, 1 = Positive, 2 = Negative, 3 = Zero}
  * Stride   bits 20-21  Vector stride
- * Len  bits 16-18  Vector length
+ * Len      bits 16-18  Vector length
  */
 
 // NZCV; QC (ASMID only), AHP; DN, FZ, RMode, Stride; SBZP; Len; trap enables; cumulative bits

--- a/src/frontend/A32/location_descriptor.h
+++ b/src/frontend/A32/location_descriptor.h
@@ -26,7 +26,7 @@ class LocationDescriptor {
 public:
     // Indicates bits that should be preserved within descriptors.
     static constexpr u32 CPSR_MODE_MASK  = 0x00000220;
-    static constexpr u32 FPSCR_MODE_MASK = 0x03F79F00;
+    static constexpr u32 FPSCR_MODE_MASK = 0x07F79F00;
 
     LocationDescriptor(u32 arm_pc, PSR cpsr, FPSCR fpscr)
             : arm_pc(arm_pc), cpsr(cpsr.Value() & CPSR_MODE_MASK), fpscr(fpscr.Value() & FPSCR_MODE_MASK) {}


### PR DESCRIPTION
Ensures the alternate half-precision state is preserved within the location descriptors, which will be necessary when implementing the half-precision extensions for VFP and NEON.