### PR TITLE
A32: Implement ARM-mode MOVW

### DIFF
--- a/src/frontend/A32/decoder/arm.inc
+++ b/src/frontend/A32/decoder/arm.inc
@@ -179,6 +179,7 @@ INST(arm_BFC,           "BFC",                 "cccc0111110vvvvvddddvvvvv0011111
 INST(arm_BFI,           "BFI",                 "cccc0111110vvvvvddddvvvvv001nnnn") // v6T2
 INST(arm_CLZ,           "CLZ",                 "cccc000101101111dddd11110001mmmm") // v5
 INST(arm_MOVT,          "MOVT",                "cccc00110100vvvvddddvvvvvvvvvvvv") // v6T2
+INST(arm_MOVW,          "MOVW",                "cccc00110000vvvvddddvvvvvvvvvvvv") // v6T2
 INST(arm_NOP,           "NOP",                 "----0011001000001111000000000000") // v6K
 INST(arm_SBFX,          "SBFX",                "cccc0111101wwwwwddddvvvvv101nnnn") // v6T2
 INST(arm_SEL,           "SEL",                 "cccc01101000nnnndddd11111011mmmm") // v6

--- a/src/frontend/A32/disassembler/disassembler_arm.cpp
+++ b/src/frontend/A32/disassembler/disassembler_arm.cpp
@@ -820,6 +820,10 @@ public:
         const u32 imm = concatenate(imm4, imm12).ZeroExtend();
         return fmt::format("movt{} {}, #{}", CondToString(cond), d, imm);
     }
+    std::string arm_MOVW(Cond cond, Imm<4> imm4, Reg d, Imm<12> imm12) {
+        const u32 imm = concatenate(imm4, imm12).ZeroExtend();
+        return fmt::format("movw{}, {}, #{}", CondToString(cond), d, imm);
+    }
     std::string arm_NOP() {
         return "nop";
     }

--- a/src/frontend/A32/translate/translate_arm/misc.cpp
+++ b/src/frontend/A32/translate/translate_arm/misc.cpp
@@ -89,6 +89,21 @@ bool ArmTranslatorVisitor::arm_MOVT(Cond cond, Imm<4> imm4, Reg d, Imm<12> imm12
     return true;
 }
 
+bool ArmTranslatorVisitor::arm_MOVW(Cond cond, Imm<4> imm4, Reg d, Imm<12> imm12) {
+    if (d == Reg::PC) {
+        return UnpredictableInstruction();
+    }
+
+    if (!ConditionPassed(cond)) {
+        return true;
+    }
+
+    const IR::U32 imm = ir.Imm32(concatenate(imm4, imm12).ZeroExtend());
+
+    ir.SetRegister(d, imm);
+    return true;
+}
+
 // SBFX<c> <Rd>, <Rn>, #<lsb>, #<width>
 bool ArmTranslatorVisitor::arm_SBFX(Cond cond, Imm<5> widthm1, Reg d, Imm<5> lsb, Reg n) {
     if (d == Reg::PC || n == Reg::PC) {

--- a/src/frontend/A32/translate/translate_arm/translate_arm.h
+++ b/src/frontend/A32/translate/translate_arm/translate_arm.h
@@ -226,6 +226,7 @@ struct ArmTranslatorVisitor final {
     bool arm_BFI(Cond cond, Imm<5> msb, Reg d, Imm<5> lsb, Reg n);
     bool arm_CLZ(Cond cond, Reg d, Reg m);
     bool arm_MOVT(Cond cond, Imm<4> imm4, Reg d, Imm<12> imm12);
+    bool arm_MOVW(Cond cond, Imm<4> imm4, Reg d, Imm<12> imm12);
     bool arm_NOP() { return true; }
     bool arm_RBIT(Cond cond, Reg d, Reg m);
     bool arm_SBFX(Cond cond, Imm<5> widthm1, Reg d, Imm<5> lsb, Reg n);


### PR DESCRIPTION
Fairly trivial. The lower-half analogue to MOVT.