### PR TITLE
General: Remove unnecessary includes

### DIFF
--- a/src/backend/x64/a32_emit_x64.cpp
+++ b/src/backend/x64/a32_emit_x64.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <unordered_map>
-#include <unordered_set>
 #include <utility>
 
 #include <fmt/format.h>

--- a/src/backend/x64/a32_emit_x64.h
+++ b/src/backend/x64/a32_emit_x64.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <array>
-#include <optional>
 
 #include <dynarmic/A32/a32.h>
 #include <dynarmic/A32/config.h>

--- a/src/backend/x64/a32_interface.cpp
+++ b/src/backend/x64/a32_interface.cpp
@@ -9,6 +9,9 @@
 #include <boost/icl/interval_set.hpp>
 #include <fmt/format.h>
 
+#include <dynarmic/A32/a32.h>
+#include <dynarmic/A32/context.h>
+
 #include "backend/x64/a32_emit_x64.h"
 #include "backend/x64/a32_jitstate.h"
 #include "backend/x64/block_of_code.h"
@@ -19,8 +22,6 @@
 #include "common/common_types.h"
 #include "common/llvm_disassemble.h"
 #include "common/scope_exit.h"
-#include "dynarmic/A32/a32.h"
-#include "dynarmic/A32/context.h"
 #include "frontend/A32/translate/translate.h"
 #include "frontend/ir/basic_block.h"
 #include "frontend/ir/location_descriptor.h"

--- a/src/backend/x64/a64_emit_x64.cpp
+++ b/src/backend/x64/a64_emit_x64.cpp
@@ -21,7 +21,6 @@
 #include "common/bit_util.h"
 #include "common/common_types.h"
 #include "common/scope_exit.h"
-#include "common/variant_util.h"
 #include "frontend/A64/location_descriptor.h"
 #include "frontend/A64/types.h"
 #include "frontend/ir/basic_block.h"

--- a/src/backend/x64/block_of_code.cpp
+++ b/src/backend/x64/block_of_code.cpp
@@ -6,7 +6,6 @@
 
 #include <array>
 #include <cstring>
-#include <limits>
 
 #include <xbyak.h>
 

--- a/src/backend/x64/block_range_information.h
+++ b/src/backend/x64/block_range_information.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <set>
 #include <unordered_set>
 
 #include <boost/icl/interval_map.hpp>

--- a/src/backend/x64/constant_pool.h
+++ b/src/backend/x64/constant_pool.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <map>
+#include <tuple>
 
 #include <xbyak.h>
 

--- a/src/backend/x64/devirtualize.h
+++ b/src/backend/x64/devirtualize.h
@@ -7,10 +7,9 @@
 #pragma once
 
 #include <cstring>
-#include <memory>
+#include <utility>
 
 #include "backend/x64/callback.h"
-#include "common/assert.h"
 #include "common/cast_util.h"
 #include "common/common_types.h"
 #include "common/mp/function_info.h"

--- a/src/backend/x64/emit_x64.h
+++ b/src/backend/x64/emit_x64.h
@@ -19,7 +19,6 @@
 #include "backend/x64/reg_alloc.h"
 #include "common/bit_util.h"
 #include "common/fp/fpcr.h"
-#include "common/fp/rounding_mode.h"
 #include "frontend/ir/location_descriptor.h"
 #include "frontend/ir/terminal.h"
 

--- a/src/backend/x64/emit_x64_aes.cpp
+++ b/src/backend/x64/emit_x64_aes.cpp
@@ -10,7 +10,6 @@
 #include "common/common_types.h"
 #include "common/crypto/aes.h"
 #include "frontend/ir/microinstruction.h"
-#include "frontend/ir/opcodes.h"
 
 namespace Dynarmic::BackendX64 {
 

--- a/src/backend/x64/emit_x64_crc32.cpp
+++ b/src/backend/x64/emit_x64_crc32.cpp
@@ -9,10 +9,8 @@
 
 #include "backend/x64/block_of_code.h"
 #include "backend/x64/emit_x64.h"
-#include "common/common_types.h"
 #include "common/crypto/crc32.h"
 #include "frontend/ir/microinstruction.h"
-#include "frontend/ir/opcodes.h"
 
 namespace Dynarmic::BackendX64 {
 

--- a/src/backend/x64/emit_x64_floating_point.cpp
+++ b/src/backend/x64/emit_x64_floating_point.cpp
@@ -18,7 +18,6 @@
 #include "common/fp/info.h"
 #include "common/fp/op.h"
 #include "common/fp/rounding_mode.h"
-#include "common/fp/util.h"
 #include "common/mp/cartesian_product.h"
 #include "common/mp/integer.h"
 #include "common/mp/list.h"
@@ -28,7 +27,6 @@
 #include "common/mp/vllift.h"
 #include "frontend/ir/basic_block.h"
 #include "frontend/ir/microinstruction.h"
-#include "frontend/ir/opcodes.h"
 
 namespace Dynarmic::BackendX64 {
 

--- a/src/backend/x64/emit_x64_packed.cpp
+++ b/src/backend/x64/emit_x64_packed.cpp
@@ -6,9 +6,6 @@
 
 #include "backend/x64/block_of_code.h"
 #include "backend/x64/emit_x64.h"
-#include "common/assert.h"
-#include "common/common_types.h"
-#include "frontend/ir/basic_block.h"
 #include "frontend/ir/microinstruction.h"
 #include "frontend/ir/opcodes.h"
 

--- a/src/backend/x64/emit_x64_sm4.cpp
+++ b/src/backend/x64/emit_x64_sm4.cpp
@@ -6,10 +6,8 @@
 
 #include "backend/x64/block_of_code.h"
 #include "backend/x64/emit_x64.h"
-#include "common/common_types.h"
 #include "common/crypto/sm4.h"
 #include "frontend/ir/microinstruction.h"
-#include "frontend/ir/opcodes.h"
 
 namespace Dynarmic::BackendX64 {
 

--- a/src/backend/x64/emit_x64_vector.cpp
+++ b/src/backend/x64/emit_x64_vector.cpp
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <bitset>
 #include <cstdlib>
-#include <functional>
 #include <type_traits>
 
 #include "backend/x64/abi.h"

--- a/src/backend/x64/emit_x64_vector_floating_point.cpp
+++ b/src/backend/x64/emit_x64_vector_floating_point.cpp
@@ -14,7 +14,6 @@
 #include "backend/x64/block_of_code.h"
 #include "backend/x64/emit_x64.h"
 #include "common/assert.h"
-#include "common/bit_util.h"
 #include "common/fp/fpcr.h"
 #include "common/fp/info.h"
 #include "common/fp/op.h"

--- a/src/backend/x64/jitstate_info.h
+++ b/src/backend/x64/jitstate_info.h
@@ -8,8 +8,6 @@
 
 #include <cstddef>
 
-#include "common/common_types.h"
-
 namespace Dynarmic::BackendX64 {
 
 struct JitStateInfo {

--- a/src/backend/x64/perf_map.h
+++ b/src/backend/x64/perf_map.h
@@ -6,8 +6,6 @@
 
 #pragma once
 
-#include <cstddef>
-#include <string>
 #include <string_view>
 
 #include "common/cast_util.h"

--- a/src/common/fp/fpsr.h
+++ b/src/common/fp/fpsr.h
@@ -6,8 +6,6 @@
 
 #pragma once
 
-#include <optional>
-
 #include "common/bit_util.h"
 #include "common/common_types.h"
 

--- a/src/common/fp/op/FPConvert.cpp
+++ b/src/common/fp/op/FPConvert.cpp
@@ -4,15 +4,12 @@
  * General Public License version 2 or any later version.
  */
 
-#include <tuple>
-
 #include "common/common_types.h"
 #include "common/fp/fpcr.h"
 #include "common/fp/fpsr.h"
 #include "common/fp/info.h"
-#include "common/fp/op/FPRecipEstimate.h"
+#include "common/fp/op/FPConvert.h"
 #include "common/fp/process_exception.h"
-#include "common/fp/process_nan.h"
 #include "common/fp/unpacked.h"
 
 namespace Dynarmic::FP {

--- a/src/common/fp/op/FPRecipExponent.cpp
+++ b/src/common/fp/op/FPRecipExponent.cpp
@@ -4,8 +4,6 @@
  * General Public License version 2 or any later version.
  */
 
-#include <tuple>
-
 #include "common/common_types.h"
 #include "common/bit_util.h"
 #include "common/fp/fpcr.h"

--- a/src/common/fp/util.h
+++ b/src/common/fp/util.h
@@ -8,7 +8,6 @@
 
 #include <optional>
 
-#include "common/common_types.h"
 #include "common/fp/fpcr.h"
 #include "common/fp/info.h"
 

--- a/src/common/u128.cpp
+++ b/src/common/u128.cpp
@@ -4,8 +4,6 @@
  * General Public License version 2 or any later version.
  */
 
-#include <array>
-
 #include "common/common_types.h"
 #include "common/u128.h"
 

--- a/src/common/u128.h
+++ b/src/common/u128.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <cstring>
 #include <tuple>
 #include <type_traits>
 

--- a/src/frontend/A32/translate/impl/translate_arm.h
+++ b/src/frontend/A32/translate/impl/translate_arm.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "common/assert.h"
 #include "common/bit_util.h"
 #include "frontend/imm.h"
 #include "frontend/A32/ir_emitter.h"

--- a/src/frontend/A32/translate/impl/translate_thumb.h
+++ b/src/frontend/A32/translate/impl/translate_thumb.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include "common/bit_util.h"
+#include "common/assert.h"
 #include "frontend/imm.h"
 #include "frontend/A32/ir_emitter.h"
 #include "frontend/A32/location_descriptor.h"

--- a/src/frontend/A32/translate/translate_thumb.cpp
+++ b/src/frontend/A32/translate/translate_thumb.cpp
@@ -17,7 +17,6 @@
 #include "frontend/A32/location_descriptor.h"
 #include "frontend/A32/translate/impl/translate_thumb.h"
 #include "frontend/A32/translate/translate.h"
-#include "frontend/A32/types.h"
 
 namespace Dynarmic::A32 {
 namespace {

--- a/src/frontend/A64/decoder/a64.h
+++ b/src/frontend/A64/decoder/a64.h
@@ -10,6 +10,7 @@
 #include <functional>
 #include <optional>
 #include <set>
+#include <string>
 #include <vector>
 
 #include "common/bit_util.h"

--- a/src/frontend/A64/ir_emitter.h
+++ b/src/frontend/A64/ir_emitter.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <initializer_list>
 #include <optional>
 
 #include <dynarmic/A64/config.h>

--- a/src/frontend/A64/translate/impl/floating_point_compare.cpp
+++ b/src/frontend/A64/translate/impl/floating_point_compare.cpp
@@ -4,8 +4,6 @@
  * General Public License version 2 or any later version.
  */
 
-#include <optional>
-
 #include "frontend/A64/translate/impl/impl.h"
 
 namespace Dynarmic::A64 {

--- a/src/frontend/A64/translate/impl/floating_point_conditional_compare.cpp
+++ b/src/frontend/A64/translate/impl/floating_point_conditional_compare.cpp
@@ -4,8 +4,6 @@
  * General Public License version 2 or any later version.
  */
 
-#include <optional>
-
 #include "frontend/A64/translate/impl/impl.h"
 
 namespace Dynarmic::A64 {

--- a/src/frontend/A64/translate/impl/floating_point_conditional_select.cpp
+++ b/src/frontend/A64/translate/impl/floating_point_conditional_select.cpp
@@ -4,8 +4,6 @@
  * General Public License version 2 or any later version.
  */
 
-#include <optional>
-
 #include "frontend/A64/translate/impl/impl.h"
 
 namespace Dynarmic::A64 {

--- a/src/frontend/A64/translate/impl/floating_point_conversion_fixed_point.cpp
+++ b/src/frontend/A64/translate/impl/floating_point_conversion_fixed_point.cpp
@@ -4,8 +4,6 @@
  * General Public License version 2 or any later version.
  */
 
-#include <optional>
-
 #include "frontend/A64/translate/impl/impl.h"
 
 namespace Dynarmic::A64 {

--- a/src/frontend/A64/translate/impl/floating_point_conversion_integer.cpp
+++ b/src/frontend/A64/translate/impl/floating_point_conversion_integer.cpp
@@ -4,8 +4,6 @@
  * General Public License version 2 or any later version.
  */
 
-#include <optional>
-
 #include "common/fp/rounding_mode.h"
 #include "frontend/A64/translate/impl/impl.h"
 

--- a/src/frontend/A64/translate/impl/floating_point_data_processing_one_register.cpp
+++ b/src/frontend/A64/translate/impl/floating_point_data_processing_one_register.cpp
@@ -4,8 +4,6 @@
  * General Public License version 2 or any later version.
  */
 
-#include <optional>
-
 #include "frontend/A64/translate/impl/impl.h"
 
 namespace Dynarmic::A64 {

--- a/src/frontend/A64/translate/impl/floating_point_data_processing_three_register.cpp
+++ b/src/frontend/A64/translate/impl/floating_point_data_processing_three_register.cpp
@@ -4,8 +4,6 @@
  * General Public License version 2 or any later version.
  */
 
-#include <optional>
-
 #include "frontend/A64/translate/impl/impl.h"
 
 namespace Dynarmic::A64 {

--- a/src/frontend/A64/translate/impl/floating_point_data_processing_two_register.cpp
+++ b/src/frontend/A64/translate/impl/floating_point_data_processing_two_register.cpp
@@ -4,8 +4,6 @@
  * General Public License version 2 or any later version.
  */
 
-#include <optional>
-
 #include "frontend/A64/translate/impl/impl.h"
 
 namespace Dynarmic::A64 {

--- a/src/frontend/A64/translate/impl/load_store_multiple_structures.cpp
+++ b/src/frontend/A64/translate/impl/load_store_multiple_structures.cpp
@@ -4,7 +4,6 @@
  * General Public License version 2 or any later version.
  */
 
-#include <tuple>
 #include <optional>
 
 #include "frontend/A64/translate/impl/impl.h"

--- a/src/frontend/A64/types.cpp
+++ b/src/frontend/A64/types.cpp
@@ -9,7 +9,6 @@
 
 #include <fmt/format.h>
 
-#include "common/bit_util.h"
 #include "frontend/A64/types.h"
 
 namespace Dynarmic::A64 {

--- a/src/frontend/A64/types.h
+++ b/src/frontend/A64/types.h
@@ -8,7 +8,6 @@
 
 #include <iosfwd>
 #include <string>
-#include <utility>
 
 #include "common/assert.h"
 #include "common/common_types.h"

--- a/src/frontend/ir/type.cpp
+++ b/src/frontend/ir/type.cpp
@@ -8,9 +8,6 @@
 #include <ostream>
 #include <string>
 
-#include <fmt/format.h>
-#include <fmt/ostream.h>
-
 #include "frontend/ir/type.h"
 
 namespace Dynarmic::IR {

--- a/src/ir_opt/a64_callback_config_pass.cpp
+++ b/src/ir_opt/a64_callback_config_pass.cpp
@@ -4,9 +4,8 @@
  * General Public License version 2 or any later version.
  */
 
-#include <array>
-
 #include <dynarmic/A64/config.h>
+
 #include "frontend/A64/ir_emitter.h"
 #include "frontend/ir/basic_block.h"
 #include "frontend/ir/microinstruction.h"

--- a/src/ir_opt/a64_get_set_elimination_pass.cpp
+++ b/src/ir_opt/a64_get_set_elimination_pass.cpp
@@ -6,11 +6,9 @@
 
 #include <array>
 
-#include "common/assert.h"
 #include "common/common_types.h"
 #include "frontend/A64/types.h"
 #include "frontend/ir/basic_block.h"
-#include "frontend/ir/ir_emitter.h"
 #include "frontend/ir/opcodes.h"
 #include "frontend/ir/value.h"
 #include "ir_opt/passes.h"

--- a/src/ir_opt/a64_merge_interpret_blocks.cpp
+++ b/src/ir_opt/a64_merge_interpret_blocks.cpp
@@ -4,12 +4,9 @@
  * General Public License version 2 or any later version.
  */
 
-#include <array>
-
 #include <boost/variant/get.hpp>
 #include <dynarmic/A64/config.h>
 
-#include "common/assert.h"
 #include "common/common_types.h"
 #include "frontend/A64/location_descriptor.h"
 #include "frontend/A64/translate/translate.h"

--- a/src/ir_opt/constant_propagation_pass.cpp
+++ b/src/ir_opt/constant_propagation_pass.cpp
@@ -4,9 +4,8 @@
  * General Public License version 2 or any later version.
  */
 
-#include <dynarmic/A32/config.h>
-
 #include "common/bit_util.h"
+#include "common/common_types.h"
 #include "frontend/ir/basic_block.h"
 #include "frontend/ir/opcodes.h"
 #include "ir_opt/passes.h"

--- a/src/ir_opt/passes.h
+++ b/src/ir_opt/passes.h
@@ -6,8 +6,14 @@
 
 #pragma once
 
-#include <dynarmic/A32/config.h>
-#include <dynarmic/A64/config.h>
+namespace Dynarmic::A32 {
+struct UserCallbacks;
+}
+
+namespace Dynarmic::A64 {
+struct UserCallbacks;
+struct UserConfig;
+}
 
 namespace Dynarmic::IR {
 class Block;


### PR DESCRIPTION
Removes unnecessary header dependencies that have accumulated over time as changes have been made. Lessens the amount of files that need to be rebuilt when the headers change.