### PR TITLE
Variable and parameters optimization

### DIFF
--- a/src/backend/x64/a32_emit_x64.cpp
+++ b/src/backend/x64/a32_emit_x64.cpp
@@ -79,7 +79,8 @@ bool A32EmitContext::FPSCR_DN() const {
 }
 
 A32EmitX64::A32EmitX64(BlockOfCode& code, A32::UserConfig config, A32::Jit* jit_interface)
-        : EmitX64(code), config(std::move(config)), jit_interface(jit_interface) {
+    : EmitX64(code), config(std::move(config)), jit_interface(jit_interface)
+	, reg_alloc(code, A32JitState::SpillCount, SpillToOpArg<A32JitState>) {
     GenMemoryAccessors();
     GenTerminalHandlers();
     code.PreludeComplete();
@@ -98,7 +99,6 @@ A32EmitX64::BlockDescriptor A32EmitX64::Emit(IR::Block& block) {
     // Start emitting.
     EmitCondPrelude(block);
 
-    RegAlloc reg_alloc{code, A32JitState::SpillCount, SpillToOpArg<A32JitState>};
     A32EmitContext ctx{reg_alloc, block};
 
     for (auto iter = block.begin(); iter != block.end(); ++iter) {

--- a/src/backend/x64/a32_emit_x64.h
+++ b/src/backend/x64/a32_emit_x64.h
@@ -50,6 +50,7 @@ protected:
     const A32::UserConfig config;
     A32::Jit* jit_interface;
     BlockRangeInformation<u32> block_ranges;
+    RegAlloc reg_alloc;
 
     struct FastDispatchEntry {
         u64 location_descriptor;

--- a/src/backend/x64/reg_alloc.cpp
+++ b/src/backend/x64/reg_alloc.cpp
@@ -298,15 +298,15 @@ void RegAlloc::Release(const Xbyak::Reg& reg) {
     LocInfo(hostloc).ReleaseOne();
 }
 
-Xbyak::Reg64 RegAlloc::ScratchGpr(HostLocList desired_locations) {
+Xbyak::Reg64 RegAlloc::ScratchGpr(const HostLocList& desired_locations) {
     return HostLocToReg64(ScratchImpl(desired_locations));
 }
 
-Xbyak::Xmm RegAlloc::ScratchXmm(HostLocList desired_locations) {
+Xbyak::Xmm RegAlloc::ScratchXmm(const HostLocList& desired_locations) {
     return HostLocToXmm(ScratchImpl(desired_locations));
 }
 
-HostLoc RegAlloc::UseImpl(IR::Value use_value, HostLocList desired_locations) {
+HostLoc RegAlloc::UseImpl(IR::Value use_value, const HostLocList& desired_locations) {
     if (use_value.IsImmediate()) {
         return LoadImmediate(use_value, ScratchImpl(desired_locations));
     }
@@ -338,7 +338,7 @@ HostLoc RegAlloc::UseImpl(IR::Value use_value, HostLocList desired_locations) {
     return destination_location;
 }
 
-HostLoc RegAlloc::UseScratchImpl(IR::Value use_value, HostLocList desired_locations) {
+HostLoc RegAlloc::UseScratchImpl(IR::Value use_value, const HostLocList& desired_locations) {
     if (use_value.IsImmediate()) {
         return LoadImmediate(use_value, ScratchImpl(desired_locations));
     }
@@ -363,7 +363,7 @@ HostLoc RegAlloc::UseScratchImpl(IR::Value use_value, HostLocList desired_locati
     return destination_location;
 }
 
-HostLoc RegAlloc::ScratchImpl(HostLocList desired_locations) {
+HostLoc RegAlloc::ScratchImpl(const HostLocList& desired_locations) {
     HostLoc location = SelectARegister(desired_locations);
     MoveOutOfTheWay(location);
     LocInfo(location).WriteLock();
@@ -432,7 +432,7 @@ void RegAlloc::AssertNoMoreUses() {
     ASSERT(std::all_of(hostloc_info.begin(), hostloc_info.end(), [](const auto& i) { return i.IsEmpty(); }));
 }
 
-HostLoc RegAlloc::SelectARegister(HostLocList desired_locations) const {
+HostLoc RegAlloc::SelectARegister(const HostLocList& desired_locations) const {
     std::vector<HostLoc> candidates = desired_locations;
 
     // Find all locations that have not been allocated..

--- a/src/backend/x64/reg_alloc.h
+++ b/src/backend/x64/reg_alloc.h
@@ -114,8 +114,8 @@ public:
 
     void Release(const Xbyak::Reg& reg);
 
-    Xbyak::Reg64 ScratchGpr(HostLocList desired_locations = any_gpr);
-    Xbyak::Xmm ScratchXmm(HostLocList desired_locations = any_xmm);
+    Xbyak::Reg64 ScratchGpr(const HostLocList& desired_locations = any_gpr);
+    Xbyak::Xmm ScratchXmm(const HostLocList& desired_locations = any_xmm);
 
     void HostCall(IR::Inst* result_def = nullptr, boost::optional<Argument&> arg0 = {}, boost::optional<Argument&> arg1 = {}, boost::optional<Argument&> arg2 = {}, boost::optional<Argument&> arg3 = {});
 
@@ -128,12 +128,12 @@ public:
 private:
     friend struct Argument;
 
-    HostLoc SelectARegister(HostLocList desired_locations) const;
+    HostLoc SelectARegister(const HostLocList& desired_locations) const;
     boost::optional<HostLoc> ValueLocation(const IR::Inst* value) const;
 
-    HostLoc UseImpl(IR::Value use_value, HostLocList desired_locations);
-    HostLoc UseScratchImpl(IR::Value use_value, HostLocList desired_locations);
-    HostLoc ScratchImpl(HostLocList desired_locations);
+    HostLoc UseImpl(IR::Value use_value, const HostLocList& desired_locations);
+    HostLoc UseScratchImpl(IR::Value use_value, const HostLocList& desired_locations);
+    HostLoc ScratchImpl(const HostLocList& desired_locations);
     void DefineValueImpl(IR::Inst* def_inst, HostLoc host_loc);
     void DefineValueImpl(IR::Inst* def_inst, const IR::Value& use_inst);
 


### PR DESCRIPTION
1. In class "A32EmitX64": move local variable "block_ranges" to class member, avoid constructor calls too  often.
2. In class "RegAlloc": Parameters use reference call method