### PR TITLE
Config: Use cycle counting to limit execution when enable_ticks is off.

### DIFF
--- a/src/backend/x64/a32_emit_x64.cpp
+++ b/src/backend/x64/a32_emit_x64.cpp
@@ -137,9 +137,7 @@ A32EmitX64::BlockDescriptor A32EmitX64::Emit(IR::Block& block) {
 
     reg_alloc.AssertNoMoreUses();
 
-    if (config.enable_ticks) {
-        EmitAddCycles(block.CycleCount());
-    }
+    EmitAddCycles(block.CycleCount());
     EmitX64::EmitTerminal(block.GetTerminal(), ctx.Location().SetSingleStepping(false), ctx.IsSingleStep());
     code.int3();
 
@@ -174,9 +172,7 @@ void A32EmitX64::EmitCondPrelude(const A32EmitContext& ctx) {
     ASSERT(ctx.block.HasConditionFailedLocation());
 
     Xbyak::Label pass = EmitCond(ctx.block.GetCondition());
-    if (config.enable_ticks) {
-        EmitAddCycles(ctx.block.ConditionFailedCycleCount());
-    }
+    EmitAddCycles(ctx.block.ConditionFailedCycleCount());
     EmitTerminal(IR::Term::LinkBlock{ctx.block.ConditionFailedLocation()}, ctx.Location().SetSingleStepping(false), ctx.IsSingleStep());
     code.L(pass);
 }
@@ -1472,11 +1468,7 @@ void A32EmitX64::EmitTerminalImpl(IR::Term::LinkBlock terminal, IR::LocationDesc
         return;
     }
 
-    if (config.enable_ticks) {
-        code.cmp(qword[r15 + offsetof(A32JitState, cycles_remaining)], 0);
-    } else {
-        code.cmp(code.byte[r15 + offsetof(A32JitState, halt_requested)], 0);
-    }
+    code.cmp(qword[r15 + offsetof(A32JitState, cycles_remaining)], 0);
 
     patch_information[terminal.next].jg.emplace_back(code.getCurr());
     if (const auto next_bb = GetBasicBlock(terminal.next)) {

--- a/src/backend/x64/a64_emit_x64.cpp
+++ b/src/backend/x64/a64_emit_x64.cpp
@@ -107,9 +107,7 @@ A64EmitX64::BlockDescriptor A64EmitX64::Emit(IR::Block& block) {
 
     reg_alloc.AssertNoMoreUses();
 
-    if (conf.enable_ticks) {
-        EmitAddCycles(block.CycleCount());
-    }
+    EmitAddCycles(block.CycleCount());
     EmitX64::EmitTerminal(block.GetTerminal(), ctx.Location().SetSingleStepping(false), ctx.IsSingleStep());
     code.int3();
 
@@ -1228,11 +1226,7 @@ void A64EmitX64::EmitTerminalImpl(IR::Term::LinkBlock terminal, IR::LocationDesc
         return;
     }
 
-    if (conf.enable_ticks) {
-        code.cmp(qword[r15 + offsetof(A64JitState, cycles_remaining)], 0);
-    } else {
-        code.cmp(code.byte[r15 + offsetof(A64JitState, halt_requested)], 0);
-    }
+    code.cmp(qword[r15 + offsetof(A64JitState, cycles_remaining)], 0);
 
     patch_information[terminal.next].jg.emplace_back(code.getCurr());
     if (auto next_bb = GetBasicBlock(terminal.next)) {

--- a/src/backend/x64/block_of_code.cpp
+++ b/src/backend/x64/block_of_code.cpp
@@ -169,11 +169,9 @@ void BlockOfCode::GenRunCode(std::function<void(BlockOfCode&)> rcp) {
     mov(r15, ABI_PARAM1);
     mov(rbx, ABI_PARAM2); // save temporarily in non-volatile register
 
-    if (cb.enable_ticks) {
-        cb.GetTicksRemaining->EmitCall(*this);
-        mov(qword[r15 + jsi.offsetof_cycles_to_run], ABI_RETURN);
-        mov(qword[r15 + jsi.offsetof_cycles_remaining], ABI_RETURN);
-    }
+    cb.GetTicksRemaining->EmitCall(*this);
+    mov(qword[r15 + jsi.offsetof_cycles_to_run], ABI_RETURN);
+    mov(qword[r15 + jsi.offsetof_cycles_remaining], ABI_RETURN);
 
     rcp(*this);
 
@@ -187,10 +185,8 @@ void BlockOfCode::GenRunCode(std::function<void(BlockOfCode&)> rcp) {
 
     mov(r15, ABI_PARAM1);
 
-    if (cb.enable_ticks) {
-        mov(qword[r15 + jsi.offsetof_cycles_to_run], 1);
-        mov(qword[r15 + jsi.offsetof_cycles_remaining], 1);
-    }
+    mov(qword[r15 + jsi.offsetof_cycles_to_run], 1);
+    mov(qword[r15 + jsi.offsetof_cycles_remaining], 1);
 
     rcp(*this);
 
@@ -206,11 +202,7 @@ void BlockOfCode::GenRunCode(std::function<void(BlockOfCode&)> rcp) {
     align();
     return_from_run_code[0] = getCurr<const void*>();
 
-    if (cb.enable_ticks) {
-        cmp(qword[r15 + jsi.offsetof_cycles_remaining], 0);
-    } else {
-        cmp(byte[r15 + jsi.offsetof_halt_requested], 0);
-    }
+    cmp(qword[r15 + jsi.offsetof_cycles_remaining], 0);
     jng(return_to_caller);
     cb.LookupBlock->EmitCall(*this);
     jmp(ABI_RETURN);
@@ -218,11 +210,7 @@ void BlockOfCode::GenRunCode(std::function<void(BlockOfCode&)> rcp) {
     align();
     return_from_run_code[MXCSR_ALREADY_EXITED] = getCurr<const void*>();
 
-    if (cb.enable_ticks) {
-        cmp(qword[r15 + jsi.offsetof_cycles_remaining], 0);
-    } else {
-        cmp(byte[r15 + jsi.offsetof_halt_requested], 0);
-    }
+    cmp(qword[r15 + jsi.offsetof_cycles_remaining], 0);
     jng(return_to_caller_mxcsr_already_exited);
     SwitchMxcsrOnEntry();
     cb.LookupBlock->EmitCall(*this);


### PR DESCRIPTION
This pull request relaxes the option `enable_ticks` to keep doing cycle counting to limit execution. This is because the current behavior of halt execution is prune to race conditions. This is a temporal measure until a better solution is found.