### PR TITLE
A32: Implement several ASIMD shift instructions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -127,6 +127,7 @@ if ("A32" IN_LIST DYNARMIC_FRONTENDS)
         frontend/A32/translate/impl/asimd_one_reg_modified_immediate.cpp
         frontend/A32/translate/impl/asimd_three_same.cpp
         frontend/A32/translate/impl/asimd_two_regs_misc.cpp
+        frontend/A32/translate/impl/asimd_two_regs_shift.cpp
         frontend/A32/translate/impl/barrier.cpp
         frontend/A32/translate/impl/branch.cpp
         frontend/A32/translate/impl/coprocessor.cpp

--- a/src/frontend/A32/decoder/asimd.h
+++ b/src/frontend/A32/decoder/asimd.h
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <functional>
 #include <optional>
+#include <set>
 #include <vector>
 
 #include "common/bit_util.h"
@@ -33,6 +34,15 @@ std::vector<ASIMDMatcher<V>> GetASIMDDecodeTable() {
     // If a matcher has more bits in its mask it is more specific, so it should come first.
     std::stable_sort(table.begin(), table.end(), [](const auto& matcher1, const auto& matcher2) {
         return Common::BitCount(matcher1.GetMask()) > Common::BitCount(matcher2.GetMask());
+    });
+
+    // Exceptions to the above rule of thumb.
+    const std::set<std::string> comes_first{
+        "VBIC, VMOV, VMVN, VORR (immediate)"
+    };
+
+    std::stable_partition(table.begin(), table.end(), [&](const auto& matcher) {
+        return comes_first.count(matcher.GetName()) > 0;
     });
 
     return table;

--- a/src/frontend/A32/decoder/asimd.inc
+++ b/src/frontend/A32/decoder/asimd.inc
@@ -64,7 +64,7 @@ INST(asimd_VRSHR,           "VRSHR",                    "1111001U1Diiiiiidddd001
 INST(asimd_VRSRA,           "VRSRA",                    "1111001U1Diiiiiidddd0011LQM1mmmm") // ASIMD
 INST(asimd_VSRI,            "VSRI",                     "111100111Diiiiiidddd0100LQM1mmmm") // ASIMD
 INST(asimd_VSHL,            "VSHL",                     "111100101Diiiiiidddd0101LQM1mmmm") // ASIMD
-//INST(asimd_VSLI,            "VSLI",                     "111100111-vvv-------0101LB-1----") // ASIMD
+INST(asimd_VSLI,            "VSLI",                     "111100111Diiiiiidddd0101LQM1mmmm") // ASIMD
 //INST(asimd_VQSHL,           "VQSHL" ,                   "1111001U1-vvv-------011xLB-1----") // ASIMD
 //INST(asimd_VSHRN,           "VSHRN",                    "111100101-vvv-------100000-1----") // ASIMD
 //INST(asimd_VRSHRN,          "VRSHRN",                   "111100101-vvv-------100001-1----") // ASIMD

--- a/src/frontend/A32/decoder/asimd.inc
+++ b/src/frontend/A32/decoder/asimd.inc
@@ -63,7 +63,7 @@ INST(asimd_SRA,             "SRA",                      "1111001U1Diiiiiidddd000
 INST(asimd_VRSHR,           "VRSHR",                    "1111001U1Diiiiiidddd0010LQM1mmmm") // ASIMD
 INST(asimd_VRSRA,           "VRSRA",                    "1111001U1Diiiiiidddd0011LQM1mmmm") // ASIMD
 //INST(asimd_VSRI,            "VSRI",                     "111100111-vvv-------0100LB-1----") // ASIMD
-//INST(asimd_VSHL,            "VSHL",                     "111100101-vvv-------0101LB-1----") // ASIMD
+INST(asimd_VSHL,            "VSHL",                     "111100101Diiiiiidddd0101LQM1mmmm") // ASIMD
 //INST(asimd_VSLI,            "VSLI",                     "111100111-vvv-------0101LB-1----") // ASIMD
 //INST(asimd_VQSHL,           "VQSHL" ,                   "1111001U1-vvv-------011xLB-1----") // ASIMD
 //INST(asimd_VSHRN,           "VSHRN",                    "111100101-vvv-------100000-1----") // ASIMD

--- a/src/frontend/A32/decoder/asimd.inc
+++ b/src/frontend/A32/decoder/asimd.inc
@@ -62,7 +62,7 @@ INST(asimd_SHR,             "SHR",                      "1111001U1Diiiiiidddd000
 INST(asimd_SRA,             "SRA",                      "1111001U1Diiiiiidddd0001LQM1mmmm") // ASIMD
 INST(asimd_VRSHR,           "VRSHR",                    "1111001U1Diiiiiidddd0010LQM1mmmm") // ASIMD
 INST(asimd_VRSRA,           "VRSRA",                    "1111001U1Diiiiiidddd0011LQM1mmmm") // ASIMD
-//INST(asimd_VSRI,            "VSRI",                     "111100111-vvv-------0100LB-1----") // ASIMD
+INST(asimd_VSRI,            "VSRI",                     "111100111Diiiiiidddd0100LQM1mmmm") // ASIMD
 INST(asimd_VSHL,            "VSHL",                     "111100101Diiiiiidddd0101LQM1mmmm") // ASIMD
 //INST(asimd_VSLI,            "VSLI",                     "111100111-vvv-------0101LB-1----") // ASIMD
 //INST(asimd_VQSHL,           "VQSHL" ,                   "1111001U1-vvv-------011xLB-1----") // ASIMD

--- a/src/frontend/A32/decoder/asimd.inc
+++ b/src/frontend/A32/decoder/asimd.inc
@@ -60,7 +60,7 @@ INST(asimd_VQSUB,           "VQSUB",                    "1111001U0Dzznnnndddd001
 // Two registers and a shift amount
 INST(asimd_SHR,             "SHR",                      "1111001U1Diiiiiidddd0000LQM1mmmm") // ASIMD
 INST(asimd_SRA,             "SRA",                      "1111001U1Diiiiiidddd0001LQM1mmmm") // ASIMD
-//INST(asimd_VRSHR,           "VRSHR",                    "1111001U1-vvv-------0010LB-1----") // ASIMD
+INST(asimd_VRSHR,           "VRSHR",                    "1111001U1Diiiiiidddd0010LQM1mmmm") // ASIMD
 //INST(asimd_VRSRA,           "VRSRA",                    "1111001U1-vvv-------0011LB-1----") // ASIMD
 //INST(asimd_VSRI,            "VSRI",                     "111100111-vvv-------0100LB-1----") // ASIMD
 //INST(asimd_VSHL,            "VSHL",                     "111100101-vvv-------0101LB-1----") // ASIMD

--- a/src/frontend/A32/decoder/asimd.inc
+++ b/src/frontend/A32/decoder/asimd.inc
@@ -58,7 +58,7 @@ INST(asimd_VQSUB,           "VQSUB",                    "1111001U0Dzznnnndddd001
 //INST(asimd_VQRDMULH,        "VQRDMULH",                 "1111001U1-BB--------1101-1-0----") // ASIMD
 
 // Two registers and a shift amount
-//INST(asimd_SHR,             "SHR",                      "1111001U1-vvv-------0000LB-1----") // ASIMD
+INST(asimd_SHR,             "SHR",                      "1111001U1Diiiiiidddd0000LQM1mmmm") // ASIMD
 //INST(asimd_SRA,             "SRA",                      "1111001U1-vvv-------0001LB-1----") // ASIMD
 //INST(asimd_VRSHR,           "VRSHR",                    "1111001U1-vvv-------0010LB-1----") // ASIMD
 //INST(asimd_VRSRA,           "VRSRA",                    "1111001U1-vvv-------0011LB-1----") // ASIMD

--- a/src/frontend/A32/decoder/asimd.inc
+++ b/src/frontend/A32/decoder/asimd.inc
@@ -59,7 +59,7 @@ INST(asimd_VQSUB,           "VQSUB",                    "1111001U0Dzznnnndddd001
 
 // Two registers and a shift amount
 INST(asimd_SHR,             "SHR",                      "1111001U1Diiiiiidddd0000LQM1mmmm") // ASIMD
-//INST(asimd_SRA,             "SRA",                      "1111001U1-vvv-------0001LB-1----") // ASIMD
+INST(asimd_SRA,             "SRA",                      "1111001U1Diiiiiidddd0001LQM1mmmm") // ASIMD
 //INST(asimd_VRSHR,           "VRSHR",                    "1111001U1-vvv-------0010LB-1----") // ASIMD
 //INST(asimd_VRSRA,           "VRSRA",                    "1111001U1-vvv-------0011LB-1----") // ASIMD
 //INST(asimd_VSRI,            "VSRI",                     "111100111-vvv-------0100LB-1----") // ASIMD

--- a/src/frontend/A32/decoder/asimd.inc
+++ b/src/frontend/A32/decoder/asimd.inc
@@ -61,7 +61,7 @@ INST(asimd_VQSUB,           "VQSUB",                    "1111001U0Dzznnnndddd001
 INST(asimd_SHR,             "SHR",                      "1111001U1Diiiiiidddd0000LQM1mmmm") // ASIMD
 INST(asimd_SRA,             "SRA",                      "1111001U1Diiiiiidddd0001LQM1mmmm") // ASIMD
 INST(asimd_VRSHR,           "VRSHR",                    "1111001U1Diiiiiidddd0010LQM1mmmm") // ASIMD
-//INST(asimd_VRSRA,           "VRSRA",                    "1111001U1-vvv-------0011LB-1----") // ASIMD
+INST(asimd_VRSRA,           "VRSRA",                    "1111001U1Diiiiiidddd0011LQM1mmmm") // ASIMD
 //INST(asimd_VSRI,            "VSRI",                     "111100111-vvv-------0100LB-1----") // ASIMD
 //INST(asimd_VSHL,            "VSHL",                     "111100101-vvv-------0101LB-1----") // ASIMD
 //INST(asimd_VSLI,            "VSLI",                     "111100111-vvv-------0101LB-1----") // ASIMD

--- a/src/frontend/A32/translate/impl/asimd_two_regs_shift.cpp
+++ b/src/frontend/A32/translate/impl/asimd_two_regs_shift.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: 0BSD
  */
 
+#include "common/assert.h"
 #include "common/bit_util.h"
 
 #include "frontend/A32/translate/impl/translate_arm.h"
@@ -53,7 +54,7 @@ bool ShiftRight(ArmTranslatorVisitor& v, bool U, bool D, size_t imm6, size_t Vd,
 
     // Technically just a related encoding (One register and modified immediate instructions)
     if (!L && Common::Bits<3, 5>(imm6) == 0) {
-        return v.UndefinedInstruction();
+        ASSERT_FALSE();
     }
 
     const auto [esize, shift_amount] = ElementSizeAndShiftAmount(true, L, imm6);
@@ -106,7 +107,7 @@ bool ArmTranslatorVisitor::asimd_VSRI(bool D, size_t imm6, size_t Vd, bool L, bo
 
     // Technically just a related encoding (One register and modified immediate instructions)
     if (!L && Common::Bits<3, 5>(imm6) == 0) {
-        return UndefinedInstruction();
+        ASSERT_FALSE();
     }
 
     const auto [esize, shift_amount] = ElementSizeAndShiftAmount(true, L, imm6);
@@ -160,7 +161,7 @@ bool ArmTranslatorVisitor::asimd_VSHL(bool D, size_t imm6, size_t Vd, bool L, bo
 
     // Technically just a related encoding (One register and modified immediate instructions)
     if (!L && Common::Bits<3, 5>(imm6) == 0) {
-        return UndefinedInstruction();
+        ASSERT_FALSE();
     }
 
     const auto [esize, shift_amount] = ElementSizeAndShiftAmount(false, L, imm6);

--- a/src/frontend/A32/translate/impl/asimd_two_regs_shift.cpp
+++ b/src/frontend/A32/translate/impl/asimd_two_regs_shift.cpp
@@ -1,0 +1,52 @@
+/* This file is part of the dynarmic project.
+ * Copyright (c) 2020 MerryMage
+ * SPDX-License-Identifier: 0BSD
+ */
+
+#include "common/bit_util.h"
+
+#include "frontend/A32/translate/impl/translate_arm.h"
+
+namespace Dynarmic::A32 {
+namespace {
+std::pair<size_t, size_t> ElementSizeAndShiftAmount(bool L, size_t imm6) {
+    if (L) {
+        return {64, 64U - imm6};
+    }
+
+    const int highest = Common::HighestSetBit(imm6 >> 3);
+    if (highest == 0) {
+        return {8, 16 - imm6};
+    }
+
+    if (highest == 1) {
+        return {16, 32U - imm6};
+    }
+
+    return {32, 64U - imm6};
+}
+} // Anonymous namespace
+
+bool ArmTranslatorVisitor::asimd_SHR(bool U, bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm) {
+    if (Q && (Common::Bit<0>(Vd) || Common::Bit<0>(Vm))) {
+        return UndefinedInstruction();
+    }
+
+    // Technically just a related encoding (One register and modified immediate instructions)
+    if (!L && Common::Bits<3, 5>(imm6) == 0) {
+        return UndefinedInstruction();
+    }
+
+    const auto [esize, shift_amount] = ElementSizeAndShiftAmount(L, imm6);
+    const auto d = ToVector(Q, Vd, D);
+    const auto m = ToVector(Q, Vm, M);
+
+    const auto reg_m = ir.GetVector(m);
+    const auto result = U ? ir.VectorLogicalShiftRight(esize, reg_m, static_cast<u8>(shift_amount))
+                          : ir.VectorArithmeticShiftRight(esize, reg_m, static_cast<u8>(shift_amount));
+
+    ir.SetVector(d, result);
+    return true;
+}
+
+} // namespace Dynarmic::A32

--- a/src/frontend/A32/translate/impl/asimd_two_regs_shift.cpp
+++ b/src/frontend/A32/translate/impl/asimd_two_regs_shift.cpp
@@ -99,6 +99,33 @@ bool ArmTranslatorVisitor::asimd_VRSRA(bool U, bool D, size_t imm6, size_t Vd, b
                       Accumulating::Accumulate, Rounding::Round);
 }
 
+bool ArmTranslatorVisitor::asimd_VSRI(bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm) {
+    if (Q && (Common::Bit<0>(Vd) || Common::Bit<0>(Vm))) {
+        return UndefinedInstruction();
+    }
+
+    // Technically just a related encoding (One register and modified immediate instructions)
+    if (!L && Common::Bits<3, 5>(imm6) == 0) {
+        return UndefinedInstruction();
+    }
+
+    const auto [esize, shift_amount] = ElementSizeAndShiftAmount(true, L, imm6);
+    const u64 mask = shift_amount == esize ? 0 : Common::Ones<u64>(esize) >> shift_amount;
+
+    const auto d = ToVector(Q, Vd, D);
+    const auto m = ToVector(Q, Vm, M);
+
+    const auto reg_m = ir.GetVector(m);
+    const auto reg_d = ir.GetVector(d);
+
+    const auto shifted = ir.VectorLogicalShiftRight(esize, reg_m, static_cast<u8>(shift_amount));
+    const auto mask_vec = ir.VectorBroadcast(esize, I(esize, mask));
+    const auto result = ir.VectorOr(ir.VectorAnd(reg_d, ir.VectorNot(mask_vec)), shifted);
+
+    ir.SetVector(d, result);
+    return true;
+}
+
 bool ArmTranslatorVisitor::asimd_VSHL(bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm) {
     if (Q && (Common::Bit<0>(Vd) || Common::Bit<0>(Vm))) {
         return UndefinedInstruction();

--- a/src/frontend/A32/translate/impl/asimd_two_regs_shift.cpp
+++ b/src/frontend/A32/translate/impl/asimd_two_regs_shift.cpp
@@ -84,4 +84,9 @@ bool ArmTranslatorVisitor::asimd_VRSHR(bool U, bool D, size_t imm6, size_t Vd, b
                       Accumulating::None, Rounding::Round);
 }
 
+bool ArmTranslatorVisitor::asimd_VRSRA(bool U, bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm) {
+    return ShiftRight(*this, U, D, imm6, Vd, L, Q, M, Vm,
+                      Accumulating::Accumulate, Rounding::Round);
+}
+
 } // namespace Dynarmic::A32

--- a/src/frontend/A32/translate/impl/asimd_two_regs_shift.cpp
+++ b/src/frontend/A32/translate/impl/asimd_two_regs_shift.cpp
@@ -9,44 +9,56 @@
 
 namespace Dynarmic::A32 {
 namespace {
+enum class Accumulating {
+    None,
+    Accumulate
+};
+
 std::pair<size_t, size_t> ElementSizeAndShiftAmount(bool L, size_t imm6) {
     if (L) {
-        return {64, 64U - imm6};
+        return {64, 64 - imm6};
     }
 
-    const int highest = Common::HighestSetBit(imm6 >> 3);
-    if (highest == 0) {
-        return {8, 16 - imm6};
-    }
-
-    if (highest == 1) {
-        return {16, 32U - imm6};
-    }
-
-    return {32, 64U - imm6};
+    const size_t esize = 8U << Common::HighestSetBit(imm6 >> 3);
+    const size_t shift_amount = (esize * 2) - imm6;
+    return {esize, shift_amount};
 }
-} // Anonymous namespace
 
-bool ArmTranslatorVisitor::asimd_SHR(bool U, bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm) {
+bool ShiftRight(ArmTranslatorVisitor& v, bool U, bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm,
+                Accumulating accumulate) {
     if (Q && (Common::Bit<0>(Vd) || Common::Bit<0>(Vm))) {
-        return UndefinedInstruction();
+        return v.UndefinedInstruction();
     }
 
     // Technically just a related encoding (One register and modified immediate instructions)
     if (!L && Common::Bits<3, 5>(imm6) == 0) {
-        return UndefinedInstruction();
+        return v.UndefinedInstruction();
     }
 
     const auto [esize, shift_amount] = ElementSizeAndShiftAmount(L, imm6);
     const auto d = ToVector(Q, Vd, D);
     const auto m = ToVector(Q, Vm, M);
 
-    const auto reg_m = ir.GetVector(m);
-    const auto result = U ? ir.VectorLogicalShiftRight(esize, reg_m, static_cast<u8>(shift_amount))
-                          : ir.VectorArithmeticShiftRight(esize, reg_m, static_cast<u8>(shift_amount));
+    const auto reg_m = v.ir.GetVector(m);
+    auto result = U ? v.ir.VectorLogicalShiftRight(esize, reg_m, static_cast<u8>(shift_amount))
+                      : v.ir.VectorArithmeticShiftRight(esize, reg_m, static_cast<u8>(shift_amount));
 
-    ir.SetVector(d, result);
+    if (accumulate == Accumulating::Accumulate) {
+        const auto reg_d = v.ir.GetVector(d);
+        result = v.ir.VectorAdd(esize, result, reg_d);
+    }
+
+    v.ir.SetVector(d, result);
     return true;
+}
+} // Anonymous namespace
+
+bool ArmTranslatorVisitor::asimd_SHR(bool U, bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm) {
+    return ShiftRight(*this, U, D, imm6, Vd, L, Q, M, Vm, Accumulating::None);
+}
+
+bool ArmTranslatorVisitor::asimd_SRA(bool U, bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm) {
+    return ShiftRight(*this, U, D, imm6, Vd, L, Q, M, Vm, Accumulating::Accumulate);
 }
 
 } // namespace Dynarmic::A32

--- a/src/frontend/A32/translate/impl/translate_arm.h
+++ b/src/frontend/A32/translate/impl/translate_arm.h
@@ -451,6 +451,9 @@ struct ArmTranslatorVisitor final {
     bool asimd_VHSUB(bool U, bool D, size_t sz, size_t Vn, size_t Vd, bool N, bool Q, bool M, size_t Vm);
     bool asimd_VQSUB(bool U, bool D, size_t sz, size_t Vn, size_t Vd, bool N, bool Q, bool M, size_t Vm);
 
+    // Two registers and a shift amount
+    bool asimd_SHR(bool U, bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm);
+
     // Advanced SIMD two register, miscellaneous
     bool asimd_VREV(bool D, size_t sz, size_t Vd, size_t op, bool Q, bool M, size_t Vm);
     bool asimd_VCLS(bool D, size_t sz, size_t Vd, bool Q, bool M, size_t Vm);

--- a/src/frontend/A32/translate/impl/translate_arm.h
+++ b/src/frontend/A32/translate/impl/translate_arm.h
@@ -457,6 +457,7 @@ struct ArmTranslatorVisitor final {
     bool asimd_VRSHR(bool U, bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm);
     bool asimd_VRSRA(bool U, bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm);
     bool asimd_VSRI(bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm);
+    bool asimd_VSLI(bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm);
     bool asimd_VSHL(bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm);
 
     // Advanced SIMD two register, miscellaneous

--- a/src/frontend/A32/translate/impl/translate_arm.h
+++ b/src/frontend/A32/translate/impl/translate_arm.h
@@ -453,6 +453,7 @@ struct ArmTranslatorVisitor final {
 
     // Two registers and a shift amount
     bool asimd_SHR(bool U, bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm);
+    bool asimd_SRA(bool U, bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm);
 
     // Advanced SIMD two register, miscellaneous
     bool asimd_VREV(bool D, size_t sz, size_t Vd, size_t op, bool Q, bool M, size_t Vm);

--- a/src/frontend/A32/translate/impl/translate_arm.h
+++ b/src/frontend/A32/translate/impl/translate_arm.h
@@ -456,6 +456,7 @@ struct ArmTranslatorVisitor final {
     bool asimd_SRA(bool U, bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm);
     bool asimd_VRSHR(bool U, bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm);
     bool asimd_VRSRA(bool U, bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm);
+    bool asimd_VSHL(bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm);
 
     // Advanced SIMD two register, miscellaneous
     bool asimd_VREV(bool D, size_t sz, size_t Vd, size_t op, bool Q, bool M, size_t Vm);

--- a/src/frontend/A32/translate/impl/translate_arm.h
+++ b/src/frontend/A32/translate/impl/translate_arm.h
@@ -454,6 +454,7 @@ struct ArmTranslatorVisitor final {
     // Two registers and a shift amount
     bool asimd_SHR(bool U, bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm);
     bool asimd_SRA(bool U, bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm);
+    bool asimd_VRSHR(bool U, bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm);
 
     // Advanced SIMD two register, miscellaneous
     bool asimd_VREV(bool D, size_t sz, size_t Vd, size_t op, bool Q, bool M, size_t Vm);

--- a/src/frontend/A32/translate/impl/translate_arm.h
+++ b/src/frontend/A32/translate/impl/translate_arm.h
@@ -456,6 +456,7 @@ struct ArmTranslatorVisitor final {
     bool asimd_SRA(bool U, bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm);
     bool asimd_VRSHR(bool U, bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm);
     bool asimd_VRSRA(bool U, bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm);
+    bool asimd_VSRI(bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm);
     bool asimd_VSHL(bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm);
 
     // Advanced SIMD two register, miscellaneous

--- a/src/frontend/A32/translate/impl/translate_arm.h
+++ b/src/frontend/A32/translate/impl/translate_arm.h
@@ -455,6 +455,7 @@ struct ArmTranslatorVisitor final {
     bool asimd_SHR(bool U, bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm);
     bool asimd_SRA(bool U, bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm);
     bool asimd_VRSHR(bool U, bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm);
+    bool asimd_VRSRA(bool U, bool D, size_t imm6, size_t Vd, bool L, bool Q, bool M, size_t Vm);
 
     // Advanced SIMD two register, miscellaneous
     bool asimd_VREV(bool D, size_t sz, size_t Vd, size_t op, bool Q, bool M, size_t Vm);


### PR DESCRIPTION
Implements the following ASIMD shift instructions:

- VSHR
- VSRA
- VRSHR
- VRSRA
- VSHL
- VSRI
- VSLI

The rest of the shift instructions will be implemented in another PR to avoid cluttering up this PR, which is already large