### PR TITLE
A32: Allow cleaning up exclusive state from the interface.

### DIFF
--- a/include/dynarmic/A32/a32.h
+++ b/include/dynarmic/A32/a32.h
@@ -87,6 +87,9 @@ public:
     void SaveContext(Context&) const;
     void LoadContext(const Context&);
 
+    /// Clears exclusive state for this core.
+    void ClearExclusiveState();
+
     /**
      * Returns true if Jit::Run was called but hasn't returned yet.
      * i.e.: We're in a callback.

--- a/src/backend/x64/a32_interface.cpp
+++ b/src/backend/x64/a32_interface.cpp
@@ -102,6 +102,10 @@ struct Jit::Impl {
         emitter.ChangeProcessorID(value);
     }
 
+    void ClearExclusiveState() {
+        jit_state.exclusive_state = 0;
+    }
+
     std::string Disassemble(const IR::LocationDescriptor& descriptor) {
         auto block = GetBasicBlock(descriptor);
         std::string result = fmt::format("address: {}\nsize: {} bytes\n", block.entrypoint, block.size);
@@ -234,6 +238,10 @@ void Jit::HaltExecution() {
 void Jit::ExceptionalExit() {
     impl->ExceptionalExit();
     is_executing = false;
+}
+
+void Jit::ClearExclusiveState() {
+    impl->ClearExclusiveState();
 }
 
 void Jit::ChangeProcessorID(size_t new_processor) {


### PR DESCRIPTION
This function is normally required for emulating certain OS mechanisms.