### PR TITLE
emit_x64_vector: GNFI implementation of byte-lane shifts

### DIFF
--- a/src/backend/x64/emit_x64_vector.cpp
+++ b/src/backend/x64/emit_x64_vector.cpp
@@ -442,7 +442,7 @@ static void ArithmeticShiftRightByte(EmitContext& ctx, BlockOfCode& code, const 
     if (code.HasAVX512_Icelake()) {
         // Do a logical shift right upon the 8x8 bit-matrix, but shift in
         // `0x80` bytes into the matrix to repeat the most significant bit.
-        const u64 zero_extend = ~(~0ull << (shift_amount)) & 0x8080808080808080;
+        const u64 zero_extend = ~(0xFFFFFFFFFFFFFFFF << shift_amount) & 0x8080808080808080;
         const u64 shift_matrix = (0x0102040810204080 >> (shift_amount * 8)) | zero_extend;
         code.vgf2p8affineqb(result, result, code.MConst(xword_b, shift_matrix), 0);
         return;

--- a/src/backend/x64/emit_x64_vector.cpp
+++ b/src/backend/x64/emit_x64_vector.cpp
@@ -439,6 +439,14 @@ void EmitX64::EmitVectorAnd(EmitContext& ctx, IR::Inst* inst) {
 }
 
 static void ArithmeticShiftRightByte(EmitContext& ctx, BlockOfCode& code, const Xbyak::Xmm& result, u8 shift_amount) {
+    if (code.HasAVX512_Icelake()) {
+        // Do a logical shift right upon the 8x8 bit-matrix, but shift in
+        // `0x80` bytes into the matrix to repeat the most significant bit.
+        const u64 zero_extend = ~(~0ull << (shift_amount)) & 0x8080808080808080;
+        const u64 shift_matrix = (0x0102040810204080 >> (shift_amount * 8)) | zero_extend;
+        code.vgf2p8affineqb(result, result, code.MConst(xword_b, shift_matrix), 0);
+        return;
+    }
     const Xbyak::Xmm tmp = ctx.reg_alloc.ScratchXmm();
 
     code.punpckhbw(tmp, result);


### PR DESCRIPTION
Optimizes our byte-lane bit-shifts into a single-instruction galois field affine transformation.

An identity 8x8 bit-matrix represented as a 64-bit integer can itself be bit-shfited which can be used to arbitrarily shift the bits of each 8-bit lane left or right. At emit-time, the 64-bit matrix constant can be generated and emitted as an embedded broadcast to allow for a fast single-instruction version of unsigned(logical) bit-shifts and possibly the signed(arithmetic) bit-shifts and rotations.