### PR TITLE
A32: Add ASID setting

### DIFF
--- a/include/dynarmic/A32/a32.h
+++ b/include/dynarmic/A32/a32.h
@@ -83,6 +83,11 @@ public:
     std::uint32_t Fpscr() const;
     void SetFpscr(std::uint32_t value);
 
+    // View and modify ASID
+    std::uint8_t Asid() const;
+    void SetAsid(std::uint8_t value);
+    std::uint8_t MaxAsidAvailable() const;
+
     Context SaveContext() const;
     void SaveContext(Context&) const;
     void LoadContext(const Context&);

--- a/src/backend/x64/a32_interface.cpp
+++ b/src/backend/x64/a32_interface.cpp
@@ -281,6 +281,18 @@ void Jit::SetFpscr(u32 value) {
     return impl->jit_state.SetFpscr(value);
 }
 
+std::uint8_t Jit::Asid() const {
+    return impl->jit_state.Asid();
+}
+
+void Jit::SetAsid(std::uint8_t value) {
+    impl->jit_state.SetAsid(value);
+}
+
+std::uint8_t Jit::MaxAsidAvailable() const {
+    return impl->jit_state.MaxAsidAvailable();
+}
+
 Context Jit::SaveContext() const {
     Context ctx;
     SaveContext(ctx);

--- a/src/backend/x64/a32_jitstate.cpp
+++ b/src/backend/x64/a32_jitstate.cpp
@@ -72,6 +72,8 @@ u32 A32JitState::Cpsr() const {
     return cpsr;
 }
 
+static constexpr u32 UPPER_LOCATION_DESCRIPTOR_CSPR_MASK = 0b11111111'00000011;
+
 void A32JitState::SetCpsr(u32 cpsr) {
     // NZCV flags
     cpsr_nzcv = NZCV::ToX64(cpsr);
@@ -84,7 +86,7 @@ void A32JitState::SetCpsr(u32 cpsr) {
     cpsr_ge |= Common::Bit<17>(cpsr) ? 0x0000FF00 : 0;
     cpsr_ge |= Common::Bit<16>(cpsr) ? 0x000000FF : 0;
 
-    upper_location_descriptor &= 0xFFFF0000;
+    upper_location_descriptor &= ~UPPER_LOCATION_DESCRIPTOR_CSPR_MASK;
     // E flag, T flag
     upper_location_descriptor |= Common::Bit<9>(cpsr) ? 2 : 0;
     upper_location_descriptor |= Common::Bit<5>(cpsr) ? 1 : 0;
@@ -210,6 +212,7 @@ u8 A32JitState::Asid() const {
 }
 
 void A32JitState::SetAsid(u8 ASID) {
+    upper_location_descriptor &= ~(ASID_MASK << ASID_BIT_SHIFT);
     upper_location_descriptor |= (ASID & ASID_MASK) << ASID_BIT_SHIFT;
 }
 

--- a/src/backend/x64/a32_jitstate.cpp
+++ b/src/backend/x64/a32_jitstate.cpp
@@ -201,4 +201,20 @@ void A32JitState::SetFpscr(u32 FPSCR) {
     }
 }
 
+constexpr u32 ASID_MASK = A32::LocationDescriptor::ASID_MASK;
+constexpr u32 ASID_BIT_SHIFT = A32::LocationDescriptor::ASID_BIT_SHIFT;
+constexpr u32 ASID_BIT_COUNT = 5;
+
+u8 A32JitState::Asid() const {
+    return (upper_location_descriptor >> ASID_BIT_SHIFT) & ASID_MASK;
+}
+
+void A32JitState::SetAsid(u8 ASID) {
+    upper_location_descriptor |= (ASID & ASID_MASK) << ASID_BIT_SHIFT;
+}
+
+u8 A32JitState::MaxAsidAvailable() const {
+    return (1 << ASID_BIT_COUNT);
+}
+
 } // namespace Dynarmic::Backend::X64

--- a/src/backend/x64/a32_jitstate.cpp
+++ b/src/backend/x64/a32_jitstate.cpp
@@ -208,7 +208,7 @@ constexpr u32 ASID_BIT_SHIFT = A32::LocationDescriptor::ASID_BIT_SHIFT;
 constexpr u32 ASID_BIT_COUNT = 5;
 
 u8 A32JitState::Asid() const {
-    return (upper_location_descriptor >> ASID_BIT_SHIFT) & ASID_MASK;
+    return static_cast<u8>((upper_location_descriptor >> ASID_BIT_SHIFT) & ASID_MASK);
 }
 
 void A32JitState::SetAsid(u8 ASID) {
@@ -217,7 +217,7 @@ void A32JitState::SetAsid(u8 ASID) {
 }
 
 u8 A32JitState::MaxAsidAvailable() const {
-    return (1 << ASID_BIT_COUNT);
+    return static_cast<u8>(1U << ASID_BIT_COUNT);
 }
 
 } // namespace Dynarmic::Backend::X64

--- a/src/backend/x64/a32_jitstate.h
+++ b/src/backend/x64/a32_jitstate.h
@@ -71,6 +71,10 @@ struct A32JitState {
     u32 Fpscr() const;
     void SetFpscr(u32 FPSCR);
 
+    u8 Asid() const;
+    void SetAsid(u8 ASID);
+    u8 MaxAsidAvailable() const;
+
     u64 GetUniqueHash() const noexcept {
         return (static_cast<u64>(upper_location_descriptor) << 32) | (static_cast<u64>(Reg[15]));
     }

--- a/src/frontend/A32/location_descriptor.h
+++ b/src/frontend/A32/location_descriptor.h
@@ -30,7 +30,7 @@ public:
     static constexpr u32 ASID_MASK = 0b11111;
     static constexpr u32 ASID_BIT_SHIFT = 3;
 
-    LocationDescriptor(u32 arm_pc, PSR cpsr, FPSCR fpscr, u8 asid, bool single_stepping = false)
+    LocationDescriptor(u32 arm_pc, PSR cpsr, FPSCR fpscr, u8 asid = 0, bool single_stepping = false)
         : arm_pc(arm_pc)
         , cpsr(cpsr.Value() & CPSR_MODE_MASK)
         , fpscr(fpscr.Value() & FPSCR_MODE_MASK)
@@ -59,7 +59,7 @@ public:
     bool SingleStepping() const { return single_stepping; }
 
     bool operator == (const LocationDescriptor& o) const {
-        return std::tie(arm_pc, cpsr, fpscr, single_stepping) == std::tie(o.arm_pc, o.cpsr, o.fpscr, single_stepping);
+        return std::tie(arm_pc, cpsr, fpscr, asid, single_stepping) == std::tie(o.arm_pc, o.cpsr, o.fpscr, o.asid, single_stepping);
     }
 
     bool operator != (const LocationDescriptor& o) const {
@@ -67,40 +67,40 @@ public:
     }
 
     LocationDescriptor SetPC(u32 new_arm_pc) const {
-        return LocationDescriptor(new_arm_pc, cpsr, fpscr, single_stepping);
+        return LocationDescriptor(new_arm_pc, cpsr, fpscr, asid, single_stepping);
     }
 
     LocationDescriptor AdvancePC(int amount) const {
-        return LocationDescriptor(static_cast<u32>(arm_pc + amount), cpsr, fpscr, single_stepping);
+        return LocationDescriptor(static_cast<u32>(arm_pc + amount), cpsr, fpscr, asid, single_stepping);
     }
 
     LocationDescriptor SetTFlag(bool new_tflag) const {
         PSR new_cpsr = cpsr;
         new_cpsr.T(new_tflag);
 
-        return LocationDescriptor(arm_pc, new_cpsr, fpscr, single_stepping);
+        return LocationDescriptor(arm_pc, new_cpsr, fpscr, asid, single_stepping);
     }
 
     LocationDescriptor SetEFlag(bool new_eflag) const {
         PSR new_cpsr = cpsr;
         new_cpsr.E(new_eflag);
 
-        return LocationDescriptor(arm_pc, new_cpsr, fpscr, single_stepping);
+        return LocationDescriptor(arm_pc, new_cpsr, fpscr, asid, single_stepping);
     }
 
     LocationDescriptor SetFPSCR(u32 new_fpscr) const {
-        return LocationDescriptor(arm_pc, cpsr, A32::FPSCR{new_fpscr & FPSCR_MODE_MASK}, single_stepping);
+        return LocationDescriptor(arm_pc, cpsr, A32::FPSCR{new_fpscr & FPSCR_MODE_MASK}, asid, single_stepping);
     }
 
     LocationDescriptor AdvanceIT() const {
         PSR new_cpsr = cpsr;
         new_cpsr.IT(new_cpsr.IT().Advance());
 
-        return LocationDescriptor(arm_pc, new_cpsr, fpscr, single_stepping);
+        return LocationDescriptor(arm_pc, new_cpsr, fpscr, asid, single_stepping);
     }
 
     LocationDescriptor SetSingleStepping(bool new_single_stepping) const {
-        return LocationDescriptor(arm_pc, cpsr, fpscr, new_single_stepping);
+        return LocationDescriptor(arm_pc, cpsr, fpscr, asid, new_single_stepping);
     }
 
     u64 UniqueHash() const noexcept {

--- a/src/frontend/A32/location_descriptor.h
+++ b/src/frontend/A32/location_descriptor.h
@@ -45,7 +45,7 @@ public:
         fpscr = (o.Value() >> 32) & FPSCR_MODE_MASK;
         cpsr.IT(ITState{static_cast<u8>(o.Value() >> 40)});
         single_stepping = (o.Value() >> 32) & 4;
-        asid = ((o.Value() >> 32) >> ASID_BIT_SHIFT) & ASID_MASK;
+        asid = static_cast<u8>(((o.Value() >> 32) >> ASID_BIT_SHIFT) & ASID_MASK);
     }
 
     u32 PC() const { return arm_pc; }


### PR DESCRIPTION
We emulate multi-process OS and sometimes apps force the code address, with some same state flags, but the data in the code block is different. And the block unique hash was collided.

Since clear the cache was not viable solution since the code got executed very frequently, I add ASID (address-space ID) to differentiate those code blocks. It fills the rest 5 bits of the upper location descriptor, making A32 upper location descriptor full now.

By default client side who don't care about this can still use the JIT fine. This is just extra advance methods.

I do this because I think the upper location description bits is stable now (likely no more addition to it).

**Edit:** I was thinking of should I create each JIT instance for each process instead, I think this would save some memory I hope while being valid solution.
