### PR TITLE
backend/{a32,a64}_emit_x64: Add config entry to mask page table pointers

### DIFF
--- a/include/dynarmic/A32/config.h
+++ b/include/dynarmic/A32/config.h
@@ -137,6 +137,11 @@ struct UserConfig {
     ///       So there might be wrongly faulted pages which maps to nullptr.
     ///       This can be avoided by carefully allocating the memory region.
     bool absolute_offset_page_table = false;
+    /// Masks out the first N bits in host pointers from the page table.
+    /// The intention behind this is to allow users of Dynarmic to pack attributes in the
+    /// same integer and update the pointer attribute pair atomically.
+    /// If the configured value is 3, all pointers will be forcefully aligned to 8 bytes.
+    int page_table_pointer_mask_bits = 0;
     /// Determines if we should detect memory accesses via page_table that straddle are
     /// misaligned. Accesses that straddle page boundaries will fallback to the relevant
     /// memory callback.

--- a/include/dynarmic/A64/config.h
+++ b/include/dynarmic/A64/config.h
@@ -188,6 +188,11 @@ struct UserConfig {
     /// Determines the size of page_table. Valid values are between 12 and 64 inclusive.
     /// This is only used if page_table is not nullptr.
     size_t page_table_address_space_bits = 36;
+    /// Masks out the first N bits in host pointers from the page table.
+    /// The intention behind this is to allow users of Dynarmic to pack attributes in the
+    /// same integer and update the pointer attribute pair atomically.
+    /// If the configured value is 3, all pointers will be forcefully aligned to 8 bytes.
+    int page_table_pointer_mask_bits = 0;
     /// Determines what happens if the guest accesses an entry that is off the end of the
     /// page table. If true, Dynarmic will silently mirror page_table's address space. If
     /// false, accessing memory outside of page_table bounds will result in a call to the

--- a/src/backend/x64/a32_emit_x64.cpp
+++ b/src/backend/x64/a32_emit_x64.cpp
@@ -935,7 +935,11 @@ Xbyak::RegExp EmitVAddrLookup(BlockOfCode& code, A32EmitContext& ctx, size_t bit
     code.mov(tmp, vaddr.cvt32());
     code.shr(tmp, static_cast<int>(page_bits));
     code.mov(page, qword[r14 + tmp.cvt64() * sizeof(void*)]);
-    code.test(page, page);
+    if (ctx.conf.page_table_pointer_mask_bits == 0) {
+        code.test(page, page);
+    } else {
+        code.and_(page, ~u32(0) << ctx.conf.page_table_pointer_mask_bits);
+    }
     code.jz(abort, code.T_NEAR);
     if (ctx.conf.absolute_offset_page_table) {
         return page + vaddr;

--- a/src/backend/x64/a64_emit_x64.cpp
+++ b/src/backend/x64/a64_emit_x64.cpp
@@ -815,7 +815,11 @@ Xbyak::RegExp EmitVAddrLookup(BlockOfCode& code, A64EmitContext& ctx, size_t bit
         code.jnz(abort, code.T_NEAR);
     }
     code.mov(page, qword[r14 + tmp * sizeof(void*)]);
-    code.test(page, page);
+    if (ctx.conf.page_table_pointer_mask_bits == 0) {
+        code.test(page, page);
+    } else {
+        code.and_(page, ~u32(0) << ctx.conf.page_table_pointer_mask_bits);
+    }
     code.jz(abort, code.T_NEAR);
     if (ctx.conf.absolute_offset_page_table) {
         return page + vaddr;


### PR DESCRIPTION
Add config entry to mask out the lower bits in page table pointers. This is intended to allow users of Dynarmic to pack small integers inside pointers and update the pair atomically without locks. These lower bits can be masked out due to the expected alignment in pointers inside the page table.

For example if pointers are guaranteed to be aligned to 8 bytes, the lower bits of all pointers in the page table will look like this:
```
... 7654 3210
nnn nnnn n000
```
These first 3 bits are guaranteed to be zero and can be used for arbitrary data as long as they are masked out when used.

yuzu in particular has 3 bits for attributes on a separate page table describing the state of the page (unmapped, mapped, cached, and others inherited from Citra currently unused). We have to be able to update both the pointer in the page table and the attributes atomically.
This is currently done with a `std::mutex`, but on highly contested situations it causes performance issues. By packing the pointer attribute pair in the same `uintptr_t`, we can update the pair in a single atomic instruction without locks. It also saves memory since the second page table for attributes is not required.

This has been tested on 32-bit and 64-bit guest applications and it seems to work as expected.

About implementation details, `AND` should set zero flag the same way as `TEST`.

I don't know if the page table pointers are used on any other place in Dynarmic. I tracked where `r14` is being used and this commit seems to cover all places.