### PR TITLE
A32: Add hook_isb option.

### DIFF
--- a/include/dynarmic/A32/config.h
+++ b/include/dynarmic/A32/config.h
@@ -90,6 +90,8 @@ struct UserCallbacks {
 
     virtual void ExceptionRaised(VAddr pc, Exception exception) = 0;
 
+    virtual void InstructionSynchronizationBarrierRaised() {}
+
     // Timing-related callbacks
     // ticks ticks have passed
     virtual void AddTicks(std::uint64_t ticks) = 0;
@@ -163,6 +165,11 @@ struct UserConfig {
 
     // Coprocessors
     std::array<std::shared_ptr<Coprocessor>, 16> coprocessors{};
+
+    /// When set to true, UserCallbacks::InstructionSynchronizationBarrierRaised will be
+    /// called when an ISB instruction is executed.
+    /// When set to false, ISB will be treated as a NOP instruction.
+    bool hook_isb = false;
 
     /// Hint instructions would cause ExceptionRaised to be called with the appropriate
     /// argument.

--- a/src/backend/x64/a32_emit_x64.cpp
+++ b/src/backend/x64/a32_emit_x64.cpp
@@ -720,10 +720,12 @@ void A32EmitX64::EmitA32DataMemoryBarrier(A32EmitContext&, IR::Inst*) {
 }
 
 void A32EmitX64::EmitA32InstructionSynchronizationBarrier(A32EmitContext& ctx, IR::Inst*) {
-    ctx.reg_alloc.HostCall(nullptr);
+    if (!conf.hook_isb) {
+       return;
+    }
 
-    code.mov(code.ABI_PARAM1, reinterpret_cast<u64>(jit_interface));
-    code.CallLambda([](A32::Jit* jit) { jit->ClearCache(); });
+    ctx.reg_alloc.HostCall(nullptr);
+    Devirtualize<&A32::UserCallbacks::InstructionSynchronizationBarrierRaised>(conf.callbacks).EmitCall(code);
 }
 
 void A32EmitX64::EmitA32BXWritePC(A32EmitContext& ctx, IR::Inst* inst) {


### PR DESCRIPTION
This is the same as 0f27368fdab3d2d1169e8dab14854e888bc9ce72, except for A32, as there are also 32-bit games that hit this issue (e.g. Megadimension Neptunia VII).