### PR TITLE
thumb32: Implement miscellaneous category instructions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -151,6 +151,7 @@ if ("A32" IN_LIST DYNARMIC_FRONTENDS)
         frontend/A32/translate/impl/synchronization.cpp
         frontend/A32/translate/impl/thumb16.cpp
         frontend/A32/translate/impl/thumb32.cpp
+        frontend/A32/translate/impl/thumb32_misc.cpp
         frontend/A32/translate/impl/translate_arm.h
         frontend/A32/translate/impl/translate_thumb.h
         frontend/A32/translate/impl/vfp.cpp

--- a/src/frontend/A32/decoder/thumb32.h
+++ b/src/frontend/A32/decoder/thumb32.h
@@ -283,7 +283,7 @@ std::optional<std::reference_wrapper<const Thumb32Matcher<V>>> DecodeThumb32(u32
         //INST(&V::thumb32_REV16,          "REV16",                    "111110101001----1111----1001----"),
         //INST(&V::thumb32_RBIT,           "RBIT",                     "111110101001----1111----1010----"),
         //INST(&V::thumb32_REVSH,          "REVSH",                    "111110101001----1111----1011----"),
-        //INST(&V::thumb32_SEL,            "SEL",                      "111110101010----1111----1000----"),
+        INST(&V::thumb32_SEL,            "SEL",                      "111110101010nnnn1111dddd1000mmmm"),
         INST(&V::thumb32_CLZ,            "CLZ",                      "111110101011nnnn1111dddd1000mmmm"),
 
         // Multiply, Multiply Accumulate, and Absolute Difference

--- a/src/frontend/A32/decoder/thumb32.h
+++ b/src/frontend/A32/decoder/thumb32.h
@@ -276,7 +276,7 @@ std::optional<std::reference_wrapper<const Thumb32Matcher<V>>> DecodeThumb32(u32
 
         // Miscellaneous Operations
         //INST(&V::thumb32_QADD,           "QADD",                     "111110101000----1111----1000----"),
-        //INST(&V::thumb32_QDADD,          "QDADD",                    "111110101000----1111----1001----"),
+        INST(&V::thumb32_QDADD,          "QDADD",                    "111110101000nnnn1111dddd1001mmmm"),
         //INST(&V::thumb32_QSUB,           "QSUB",                     "111110101000----1111----1010----"),
         INST(&V::thumb32_QDSUB,          "QDSUB",                    "111110101000nnnn1111dddd1011mmmm"),
         INST(&V::thumb32_REV,            "REV",                      "111110101001nnnn1111dddd1000mmmm"),

--- a/src/frontend/A32/decoder/thumb32.h
+++ b/src/frontend/A32/decoder/thumb32.h
@@ -284,7 +284,7 @@ std::optional<std::reference_wrapper<const Thumb32Matcher<V>>> DecodeThumb32(u32
         //INST(&V::thumb32_RBIT,           "RBIT",                     "111110101001----1111----1010----"),
         //INST(&V::thumb32_REVSH,          "REVSH",                    "111110101001----1111----1011----"),
         //INST(&V::thumb32_SEL,            "SEL",                      "111110101010----1111----1000----"),
-        //INST(&V::thumb32_CLZ,            "CLZ",                      "111110101011----1111----1000----"),
+        INST(&V::thumb32_CLZ,            "CLZ",                      "111110101011nnnn1111dddd1000mmmm"),
 
         // Multiply, Multiply Accumulate, and Absolute Difference
         //INST(&V::thumb32_MUL,            "MUL",                      "111110110000----1111----0000----"),

--- a/src/frontend/A32/decoder/thumb32.h
+++ b/src/frontend/A32/decoder/thumb32.h
@@ -282,7 +282,7 @@ std::optional<std::reference_wrapper<const Thumb32Matcher<V>>> DecodeThumb32(u32
         //INST(&V::thumb32_REV,            "REV",                      "111110101001----1111----1000----"),
         //INST(&V::thumb32_REV16,          "REV16",                    "111110101001----1111----1001----"),
         //INST(&V::thumb32_RBIT,           "RBIT",                     "111110101001----1111----1010----"),
-        //INST(&V::thumb32_REVSH,          "REVSH",                    "111110101001----1111----1011----"),
+        INST(&V::thumb32_REVSH,          "REVSH",                    "111110101001nnnn1111dddd1011mmmm"),
         INST(&V::thumb32_SEL,            "SEL",                      "111110101010nnnn1111dddd1000mmmm"),
         INST(&V::thumb32_CLZ,            "CLZ",                      "111110101011nnnn1111dddd1000mmmm"),
 

--- a/src/frontend/A32/decoder/thumb32.h
+++ b/src/frontend/A32/decoder/thumb32.h
@@ -275,7 +275,7 @@ std::optional<std::reference_wrapper<const Thumb32Matcher<V>>> DecodeThumb32(u32
         //INST(&V::thumb32_UHSUB8,         "UHSUB8",                   "111110101100----1111----0110----"),
 
         // Miscellaneous Operations
-        //INST(&V::thumb32_QADD,           "QADD",                     "111110101000----1111----1000----"),
+        INST(&V::thumb32_QADD,           "QADD",                     "111110101000nnnn1111dddd1000mmmm"),
         INST(&V::thumb32_QDADD,          "QDADD",                    "111110101000nnnn1111dddd1001mmmm"),
         INST(&V::thumb32_QSUB,           "QSUB",                     "111110101000nnnn1111dddd1010mmmm"),
         INST(&V::thumb32_QDSUB,          "QDSUB",                    "111110101000nnnn1111dddd1011mmmm"),

--- a/src/frontend/A32/decoder/thumb32.h
+++ b/src/frontend/A32/decoder/thumb32.h
@@ -279,7 +279,7 @@ std::optional<std::reference_wrapper<const Thumb32Matcher<V>>> DecodeThumb32(u32
         //INST(&V::thumb32_QDADD,          "QDADD",                    "111110101000----1111----1001----"),
         //INST(&V::thumb32_QSUB,           "QSUB",                     "111110101000----1111----1010----"),
         //INST(&V::thumb32_QDSUB,          "QDSUB",                    "111110101000----1111----1011----"),
-        //INST(&V::thumb32_REV,            "REV",                      "111110101001----1111----1000----"),
+        INST(&V::thumb32_REV,            "REV",                      "111110101001nnnn1111dddd1000mmmm"),
         INST(&V::thumb32_REV16,          "REV16",                    "111110101001nnnn1111dddd1001mmmm"),
         INST(&V::thumb32_RBIT,           "RBIT",                     "111110101001nnnn1111dddd1010mmmm"),
         INST(&V::thumb32_REVSH,          "REVSH",                    "111110101001nnnn1111dddd1011mmmm"),

--- a/src/frontend/A32/decoder/thumb32.h
+++ b/src/frontend/A32/decoder/thumb32.h
@@ -280,7 +280,7 @@ std::optional<std::reference_wrapper<const Thumb32Matcher<V>>> DecodeThumb32(u32
         //INST(&V::thumb32_QSUB,           "QSUB",                     "111110101000----1111----1010----"),
         //INST(&V::thumb32_QDSUB,          "QDSUB",                    "111110101000----1111----1011----"),
         //INST(&V::thumb32_REV,            "REV",                      "111110101001----1111----1000----"),
-        //INST(&V::thumb32_REV16,          "REV16",                    "111110101001----1111----1001----"),
+        INST(&V::thumb32_REV16,          "REV16",                    "111110101001nnnn1111dddd1001mmmm"),
         INST(&V::thumb32_RBIT,           "RBIT",                     "111110101001nnnn1111dddd1010mmmm"),
         INST(&V::thumb32_REVSH,          "REVSH",                    "111110101001nnnn1111dddd1011mmmm"),
         INST(&V::thumb32_SEL,            "SEL",                      "111110101010nnnn1111dddd1000mmmm"),

--- a/src/frontend/A32/decoder/thumb32.h
+++ b/src/frontend/A32/decoder/thumb32.h
@@ -281,7 +281,7 @@ std::optional<std::reference_wrapper<const Thumb32Matcher<V>>> DecodeThumb32(u32
         //INST(&V::thumb32_QDSUB,          "QDSUB",                    "111110101000----1111----1011----"),
         //INST(&V::thumb32_REV,            "REV",                      "111110101001----1111----1000----"),
         //INST(&V::thumb32_REV16,          "REV16",                    "111110101001----1111----1001----"),
-        //INST(&V::thumb32_RBIT,           "RBIT",                     "111110101001----1111----1010----"),
+        INST(&V::thumb32_RBIT,           "RBIT",                     "111110101001nnnn1111dddd1010mmmm"),
         INST(&V::thumb32_REVSH,          "REVSH",                    "111110101001nnnn1111dddd1011mmmm"),
         INST(&V::thumb32_SEL,            "SEL",                      "111110101010nnnn1111dddd1000mmmm"),
         INST(&V::thumb32_CLZ,            "CLZ",                      "111110101011nnnn1111dddd1000mmmm"),

--- a/src/frontend/A32/decoder/thumb32.h
+++ b/src/frontend/A32/decoder/thumb32.h
@@ -277,7 +277,7 @@ std::optional<std::reference_wrapper<const Thumb32Matcher<V>>> DecodeThumb32(u32
         // Miscellaneous Operations
         //INST(&V::thumb32_QADD,           "QADD",                     "111110101000----1111----1000----"),
         INST(&V::thumb32_QDADD,          "QDADD",                    "111110101000nnnn1111dddd1001mmmm"),
-        //INST(&V::thumb32_QSUB,           "QSUB",                     "111110101000----1111----1010----"),
+        INST(&V::thumb32_QSUB,           "QSUB",                     "111110101000nnnn1111dddd1010mmmm"),
         INST(&V::thumb32_QDSUB,          "QDSUB",                    "111110101000nnnn1111dddd1011mmmm"),
         INST(&V::thumb32_REV,            "REV",                      "111110101001nnnn1111dddd1000mmmm"),
         INST(&V::thumb32_REV16,          "REV16",                    "111110101001nnnn1111dddd1001mmmm"),

--- a/src/frontend/A32/decoder/thumb32.h
+++ b/src/frontend/A32/decoder/thumb32.h
@@ -278,7 +278,7 @@ std::optional<std::reference_wrapper<const Thumb32Matcher<V>>> DecodeThumb32(u32
         //INST(&V::thumb32_QADD,           "QADD",                     "111110101000----1111----1000----"),
         //INST(&V::thumb32_QDADD,          "QDADD",                    "111110101000----1111----1001----"),
         //INST(&V::thumb32_QSUB,           "QSUB",                     "111110101000----1111----1010----"),
-        //INST(&V::thumb32_QDSUB,          "QDSUB",                    "111110101000----1111----1011----"),
+        INST(&V::thumb32_QDSUB,          "QDSUB",                    "111110101000nnnn1111dddd1011mmmm"),
         INST(&V::thumb32_REV,            "REV",                      "111110101001nnnn1111dddd1000mmmm"),
         INST(&V::thumb32_REV16,          "REV16",                    "111110101001nnnn1111dddd1001mmmm"),
         INST(&V::thumb32_RBIT,           "RBIT",                     "111110101001nnnn1111dddd1010mmmm"),

--- a/src/frontend/A32/translate/impl/thumb32_misc.cpp
+++ b/src/frontend/A32/translate/impl/thumb32_misc.cpp
@@ -51,6 +51,20 @@ bool ThumbTranslatorVisitor::thumb32_QDSUB(Reg n, Reg d, Reg m) {
     return true;
 }
 
+bool ThumbTranslatorVisitor::thumb32_QSUB(Reg n, Reg d, Reg m) {
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
+        return UnpredictableInstruction();
+    }
+
+    const auto reg_m = ir.GetRegister(m);
+    const auto reg_n = ir.GetRegister(n);
+    const auto result = ir.SignedSaturatedSub(reg_m, reg_n);
+
+    ir.SetRegister(d, result.result);
+    ir.OrQFlag(result.overflow);
+    return true;
+}
+
 bool ThumbTranslatorVisitor::thumb32_RBIT(Reg n, Reg d, Reg m) {
     if (m != n || d == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();

--- a/src/frontend/A32/translate/impl/thumb32_misc.cpp
+++ b/src/frontend/A32/translate/impl/thumb32_misc.cpp
@@ -19,6 +19,31 @@ bool ThumbTranslatorVisitor::thumb32_CLZ(Reg n, Reg d, Reg m) {
     return true;
 }
 
+bool ThumbTranslatorVisitor::thumb32_RBIT(Reg n, Reg d, Reg m) {
+    if (m != n || d == Reg::PC || m == Reg::PC) {
+        return UnpredictableInstruction();
+    }
+
+    const IR::U32 swapped = ir.ByteReverseWord(ir.GetRegister(m));
+
+    // ((x & 0xF0F0F0F0) >> 4) | ((x & 0x0F0F0F0F) << 4)
+    const IR::U32 first_lsr = ir.LogicalShiftRight(ir.And(swapped, ir.Imm32(0xF0F0F0F0)), ir.Imm8(4));
+    const IR::U32 first_lsl = ir.LogicalShiftLeft(ir.And(swapped, ir.Imm32(0x0F0F0F0F)), ir.Imm8(4));
+    const IR::U32 corrected = ir.Or(first_lsl, first_lsr);
+
+    // ((x & 0x88888888) >> 3) | ((x & 0x44444444) >> 1) |
+    // ((x & 0x22222222) << 1) | ((x & 0x11111111) << 3)
+    const IR::U32 second_lsr = ir.LogicalShiftRight(ir.And(corrected, ir.Imm32(0x88888888)), ir.Imm8(3));
+    const IR::U32 third_lsr = ir.LogicalShiftRight(ir.And(corrected, ir.Imm32(0x44444444)), ir.Imm8(1));
+    const IR::U32 second_lsl = ir.LogicalShiftLeft(ir.And(corrected, ir.Imm32(0x22222222)), ir.Imm8(1));
+    const IR::U32 third_lsl = ir.LogicalShiftLeft(ir.And(corrected, ir.Imm32(0x11111111)), ir.Imm8(3));
+
+    const IR::U32 result = ir.Or(ir.Or(ir.Or(second_lsr, third_lsr), second_lsl), third_lsl);
+
+    ir.SetRegister(d, result);
+    return true;
+}
+
 bool ThumbTranslatorVisitor::thumb32_REVSH(Reg n, Reg d, Reg m) {
     if (m != n || d == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();

--- a/src/frontend/A32/translate/impl/thumb32_misc.cpp
+++ b/src/frontend/A32/translate/impl/thumb32_misc.cpp
@@ -19,6 +19,22 @@ bool ThumbTranslatorVisitor::thumb32_CLZ(Reg n, Reg d, Reg m) {
     return true;
 }
 
+bool ThumbTranslatorVisitor::thumb32_QDSUB(Reg n, Reg d, Reg m) {
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
+        return UnpredictableInstruction();
+    }
+
+    const auto reg_m = ir.GetRegister(m);
+    const auto reg_n = ir.GetRegister(n);
+    const auto doubled_n = ir.SignedSaturatedAdd(reg_n, reg_n);
+    ir.OrQFlag(doubled_n.overflow);
+
+    const auto result = ir.SignedSaturatedSub(reg_m, doubled_n.result);
+    ir.SetRegister(d, result.result);
+    ir.OrQFlag(result.overflow);
+    return true;
+}
+
 bool ThumbTranslatorVisitor::thumb32_RBIT(Reg n, Reg d, Reg m) {
     if (m != n || d == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();

--- a/src/frontend/A32/translate/impl/thumb32_misc.cpp
+++ b/src/frontend/A32/translate/impl/thumb32_misc.cpp
@@ -19,6 +19,20 @@ bool ThumbTranslatorVisitor::thumb32_CLZ(Reg n, Reg d, Reg m) {
     return true;
 }
 
+bool ThumbTranslatorVisitor::thumb32_QADD(Reg n, Reg d, Reg m) {
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
+        return UnpredictableInstruction();
+    }
+
+    const auto reg_m = ir.GetRegister(m);
+    const auto reg_n = ir.GetRegister(n);
+    const auto result = ir.SignedSaturatedAdd(reg_m, reg_n);
+
+    ir.SetRegister(d, result.result);
+    ir.OrQFlag(result.overflow);
+    return true;
+}
+
 bool ThumbTranslatorVisitor::thumb32_QDADD(Reg n, Reg d, Reg m) {
     if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();

--- a/src/frontend/A32/translate/impl/thumb32_misc.cpp
+++ b/src/frontend/A32/translate/impl/thumb32_misc.cpp
@@ -44,6 +44,20 @@ bool ThumbTranslatorVisitor::thumb32_RBIT(Reg n, Reg d, Reg m) {
     return true;
 }
 
+bool ThumbTranslatorVisitor::thumb32_REV16(Reg n, Reg d, Reg m) {
+    if (m != n || d == Reg::PC || m == Reg::PC) {
+        return UnpredictableInstruction();
+    }
+
+    const auto reg_m = ir.GetRegister(m);
+    const auto lo = ir.And(ir.LogicalShiftRight(reg_m, ir.Imm8(8), ir.Imm1(0)).result, ir.Imm32(0x00FF00FF));
+    const auto hi = ir.And(ir.LogicalShiftLeft(reg_m, ir.Imm8(8), ir.Imm1(0)).result, ir.Imm32(0xFF00FF00));
+    const auto result = ir.Or(lo, hi);
+
+    ir.SetRegister(d, result);
+    return true;
+}
+
 bool ThumbTranslatorVisitor::thumb32_REVSH(Reg n, Reg d, Reg m) {
     if (m != n || d == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();

--- a/src/frontend/A32/translate/impl/thumb32_misc.cpp
+++ b/src/frontend/A32/translate/impl/thumb32_misc.cpp
@@ -44,6 +44,17 @@ bool ThumbTranslatorVisitor::thumb32_RBIT(Reg n, Reg d, Reg m) {
     return true;
 }
 
+bool ThumbTranslatorVisitor::thumb32_REV(Reg n, Reg d, Reg m) {
+    if (m != n || d == Reg::PC || m == Reg::PC) {
+        return UnpredictableInstruction();
+    }
+
+    const auto result = ir.ByteReverseWord(ir.GetRegister(m));
+
+    ir.SetRegister(d, result);
+    return true;
+}
+
 bool ThumbTranslatorVisitor::thumb32_REV16(Reg n, Reg d, Reg m) {
     if (m != n || d == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();

--- a/src/frontend/A32/translate/impl/thumb32_misc.cpp
+++ b/src/frontend/A32/translate/impl/thumb32_misc.cpp
@@ -1,0 +1,22 @@
+/* This file is part of the dynarmic project.
+ * Copyright (c) 2016 MerryMage
+ * SPDX-License-Identifier: 0BSD
+ */
+
+#include "frontend/A32/translate/impl/translate_thumb.h"
+
+namespace Dynarmic::A32 {
+
+bool ThumbTranslatorVisitor::thumb32_CLZ(Reg n, Reg d, Reg m) {
+    if (m != n || d == Reg::PC || m == Reg::PC) {
+        return UnpredictableInstruction();
+    }
+
+    const auto reg_m = ir.GetRegister(m);
+    const auto result = ir.CountLeadingZeros(reg_m);
+
+    ir.SetRegister(d, result);
+    return true;
+}
+
+} // namespace Dynarmic::A32

--- a/src/frontend/A32/translate/impl/thumb32_misc.cpp
+++ b/src/frontend/A32/translate/impl/thumb32_misc.cpp
@@ -19,4 +19,17 @@ bool ThumbTranslatorVisitor::thumb32_CLZ(Reg n, Reg d, Reg m) {
     return true;
 }
 
+bool ThumbTranslatorVisitor::thumb32_SEL(Reg n, Reg d, Reg m) {
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
+        return UnpredictableInstruction();
+    }
+
+    const auto reg_m = ir.GetRegister(m);
+    const auto reg_n = ir.GetRegister(n);
+    const auto result = ir.PackedSelect(ir.GetGEFlags(), reg_m, reg_n);
+
+    ir.SetRegister(d, result);
+    return true;
+}
+
 } // namespace Dynarmic::A32

--- a/src/frontend/A32/translate/impl/thumb32_misc.cpp
+++ b/src/frontend/A32/translate/impl/thumb32_misc.cpp
@@ -19,6 +19,18 @@ bool ThumbTranslatorVisitor::thumb32_CLZ(Reg n, Reg d, Reg m) {
     return true;
 }
 
+bool ThumbTranslatorVisitor::thumb32_REVSH(Reg n, Reg d, Reg m) {
+    if (m != n || d == Reg::PC || m == Reg::PC) {
+        return UnpredictableInstruction();
+    }
+
+    const auto reg_m = ir.GetRegister(m);
+    const auto rev_half = ir.ByteReverseHalf(ir.LeastSignificantHalf(reg_m));
+
+    ir.SetRegister(d, ir.SignExtendHalfToWord(rev_half));
+    return true;
+}
+
 bool ThumbTranslatorVisitor::thumb32_SEL(Reg n, Reg d, Reg m) {
     if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();

--- a/src/frontend/A32/translate/impl/thumb32_misc.cpp
+++ b/src/frontend/A32/translate/impl/thumb32_misc.cpp
@@ -19,6 +19,22 @@ bool ThumbTranslatorVisitor::thumb32_CLZ(Reg n, Reg d, Reg m) {
     return true;
 }
 
+bool ThumbTranslatorVisitor::thumb32_QDADD(Reg n, Reg d, Reg m) {
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
+        return UnpredictableInstruction();
+    }
+
+    const auto reg_m = ir.GetRegister(m);
+    const auto reg_n = ir.GetRegister(n);
+    const auto doubled_n = ir.SignedSaturatedAdd(reg_n, reg_n);
+    ir.OrQFlag(doubled_n.overflow);
+
+    const auto result = ir.SignedSaturatedAdd(reg_m, doubled_n.result);
+    ir.SetRegister(d, result.result);
+    ir.OrQFlag(result.overflow);
+    return true;
+}
+
 bool ThumbTranslatorVisitor::thumb32_QDSUB(Reg n, Reg d, Reg m) {
     if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();

--- a/src/frontend/A32/translate/impl/translate_thumb.h
+++ b/src/frontend/A32/translate/impl/translate_thumb.h
@@ -118,6 +118,7 @@ struct ThumbTranslatorVisitor final {
 
     // thumb32 miscellaneous instructions
     bool thumb32_CLZ(Reg n, Reg d, Reg m);
+    bool thumb32_SEL(Reg n, Reg d, Reg m);
 };
 
 } // namespace Dynarmic::A32

--- a/src/frontend/A32/translate/impl/translate_thumb.h
+++ b/src/frontend/A32/translate/impl/translate_thumb.h
@@ -118,6 +118,7 @@ struct ThumbTranslatorVisitor final {
 
     // thumb32 miscellaneous instructions
     bool thumb32_CLZ(Reg n, Reg d, Reg m);
+    bool thumb32_QDSUB(Reg n, Reg d, Reg m);
     bool thumb32_RBIT(Reg n, Reg d, Reg m);
     bool thumb32_REV(Reg n, Reg d, Reg m);
     bool thumb32_REV16(Reg n, Reg d, Reg m);

--- a/src/frontend/A32/translate/impl/translate_thumb.h
+++ b/src/frontend/A32/translate/impl/translate_thumb.h
@@ -119,6 +119,7 @@ struct ThumbTranslatorVisitor final {
     // thumb32 miscellaneous instructions
     bool thumb32_CLZ(Reg n, Reg d, Reg m);
     bool thumb32_RBIT(Reg n, Reg d, Reg m);
+    bool thumb32_REV(Reg n, Reg d, Reg m);
     bool thumb32_REV16(Reg n, Reg d, Reg m);
     bool thumb32_REVSH(Reg n, Reg d, Reg m);
     bool thumb32_SEL(Reg n, Reg d, Reg m);

--- a/src/frontend/A32/translate/impl/translate_thumb.h
+++ b/src/frontend/A32/translate/impl/translate_thumb.h
@@ -115,6 +115,9 @@ struct ThumbTranslatorVisitor final {
     bool thumb32_BL_imm(Imm<11> hi, Imm<11> lo);
     bool thumb32_BLX_imm(Imm<11> hi, Imm<11> lo);
     bool thumb32_UDF();
+
+    // thumb32 miscellaneous instructions
+    bool thumb32_CLZ(Reg n, Reg d, Reg m);
 };
 
 } // namespace Dynarmic::A32

--- a/src/frontend/A32/translate/impl/translate_thumb.h
+++ b/src/frontend/A32/translate/impl/translate_thumb.h
@@ -119,6 +119,7 @@ struct ThumbTranslatorVisitor final {
     // thumb32 miscellaneous instructions
     bool thumb32_CLZ(Reg n, Reg d, Reg m);
     bool thumb32_RBIT(Reg n, Reg d, Reg m);
+    bool thumb32_REV16(Reg n, Reg d, Reg m);
     bool thumb32_REVSH(Reg n, Reg d, Reg m);
     bool thumb32_SEL(Reg n, Reg d, Reg m);
 };

--- a/src/frontend/A32/translate/impl/translate_thumb.h
+++ b/src/frontend/A32/translate/impl/translate_thumb.h
@@ -118,6 +118,7 @@ struct ThumbTranslatorVisitor final {
 
     // thumb32 miscellaneous instructions
     bool thumb32_CLZ(Reg n, Reg d, Reg m);
+    bool thumb32_QDADD(Reg n, Reg d, Reg m);
     bool thumb32_QDSUB(Reg n, Reg d, Reg m);
     bool thumb32_RBIT(Reg n, Reg d, Reg m);
     bool thumb32_REV(Reg n, Reg d, Reg m);

--- a/src/frontend/A32/translate/impl/translate_thumb.h
+++ b/src/frontend/A32/translate/impl/translate_thumb.h
@@ -118,6 +118,7 @@ struct ThumbTranslatorVisitor final {
 
     // thumb32 miscellaneous instructions
     bool thumb32_CLZ(Reg n, Reg d, Reg m);
+    bool thumb32_REVSH(Reg n, Reg d, Reg m);
     bool thumb32_SEL(Reg n, Reg d, Reg m);
 };
 

--- a/src/frontend/A32/translate/impl/translate_thumb.h
+++ b/src/frontend/A32/translate/impl/translate_thumb.h
@@ -120,6 +120,7 @@ struct ThumbTranslatorVisitor final {
     bool thumb32_CLZ(Reg n, Reg d, Reg m);
     bool thumb32_QDADD(Reg n, Reg d, Reg m);
     bool thumb32_QDSUB(Reg n, Reg d, Reg m);
+    bool thumb32_QSUB(Reg n, Reg d, Reg m);
     bool thumb32_RBIT(Reg n, Reg d, Reg m);
     bool thumb32_REV(Reg n, Reg d, Reg m);
     bool thumb32_REV16(Reg n, Reg d, Reg m);

--- a/src/frontend/A32/translate/impl/translate_thumb.h
+++ b/src/frontend/A32/translate/impl/translate_thumb.h
@@ -118,6 +118,7 @@ struct ThumbTranslatorVisitor final {
 
     // thumb32 miscellaneous instructions
     bool thumb32_CLZ(Reg n, Reg d, Reg m);
+    bool thumb32_QADD(Reg n, Reg d, Reg m);
     bool thumb32_QDADD(Reg n, Reg d, Reg m);
     bool thumb32_QDSUB(Reg n, Reg d, Reg m);
     bool thumb32_QSUB(Reg n, Reg d, Reg m);

--- a/src/frontend/A32/translate/impl/translate_thumb.h
+++ b/src/frontend/A32/translate/impl/translate_thumb.h
@@ -118,6 +118,7 @@ struct ThumbTranslatorVisitor final {
 
     // thumb32 miscellaneous instructions
     bool thumb32_CLZ(Reg n, Reg d, Reg m);
+    bool thumb32_RBIT(Reg n, Reg d, Reg m);
     bool thumb32_REVSH(Reg n, Reg d, Reg m);
     bool thumb32_SEL(Reg n, Reg d, Reg m);
 };

--- a/tests/A32/fuzz_thumb.cpp
+++ b/tests/A32/fuzz_thumb.cpp
@@ -249,7 +249,7 @@ void FuzzJitThumb32(const size_t instruction_count, const size_t instructions_to
     }
 }
 
-TEST_CASE("Fuzz Thumb instructions set 1", "[JitX64][Thumb]") {
+TEST_CASE("Fuzz Thumb instructions set 1", "[JitX64][Thumb][Thumb16]") {
     const std::array instructions = {
         ThumbInstGen("00000xxxxxxxxxxx"), // LSL <Rd>, <Rm>, #<imm5>
         ThumbInstGen("00001xxxxxxxxxxx"), // LSR <Rd>, <Rm>, #<imm5>
@@ -317,7 +317,7 @@ TEST_CASE("Fuzz Thumb instructions set 1", "[JitX64][Thumb]") {
 #endif
 }
 
-TEST_CASE("Fuzz Thumb instructions set 2 (affects PC)", "[JitX64][Thumb]") {
+TEST_CASE("Fuzz Thumb instructions set 2 (affects PC)", "[JitX64][Thumb][Thumb16]") {
     const std::array instructions = {
         // TODO: We currently can't test BX/BLX as we have
         //       no way of preventing the unpredictable
@@ -393,7 +393,7 @@ TEST_CASE("Fuzz Thumb32 instructions set", "[JitX64][Thumb][Thumb32]") {
     }
 }
 
-TEST_CASE("Verify fix for off by one error in MemoryRead32 worked", "[Thumb]") {
+TEST_CASE("Verify fix for off by one error in MemoryRead32 worked", "[Thumb][Thumb16]") {
     ThumbTestEnv test_env;
 
     // Prepare test subjects

--- a/tests/A32/fuzz_thumb.cpp
+++ b/tests/A32/fuzz_thumb.cpp
@@ -376,6 +376,13 @@ TEST_CASE("Fuzz Thumb32 instructions set", "[JitX64][Thumb][Thumb32]") {
                          const auto n = Common::Bits<16, 19>(inst);
                          return m == n && d != 15 && m != 15;
                      }),
+        ThumbInstGen("111110101001nnnn1111dddd1001mmmm", // REV16
+                     [](u32 inst) {
+                         const auto d = Common::Bits<8, 11>(inst);
+                         const auto m = Common::Bits<0, 3>(inst);
+                         const auto n = Common::Bits<16, 19>(inst);
+                         return m == n && d != 15 && m != 15;
+                     }),
         ThumbInstGen("111110101001nnnn1111dddd1011mmmm", // REVSH
                      [](u32 inst) {
                          const auto d = Common::Bits<8, 11>(inst);

--- a/tests/A32/fuzz_thumb.cpp
+++ b/tests/A32/fuzz_thumb.cpp
@@ -383,6 +383,13 @@ TEST_CASE("Fuzz Thumb32 instructions set", "[JitX64][Thumb][Thumb32]") {
                          const auto n = Common::Bits<16, 19>(inst);
                          return d != 15 && m != 15 && n != 15;
                      }),
+        ThumbInstGen("111110101000nnnn1111dddd1010mmmm", // QSUB
+                     [](u32 inst) {
+                         const auto d = Common::Bits<8, 11>(inst);
+                         const auto m = Common::Bits<0, 3>(inst);
+                         const auto n = Common::Bits<16, 19>(inst);
+                         return d != 15 && m != 15 && n != 15;
+                     }),
         ThumbInstGen("111110101001nnnn1111dddd1010mmmm", // RBIT
                      [](u32 inst) {
                          const auto d = Common::Bits<8, 11>(inst);

--- a/tests/A32/fuzz_thumb.cpp
+++ b/tests/A32/fuzz_thumb.cpp
@@ -369,6 +369,13 @@ TEST_CASE("Fuzz Thumb32 instructions set", "[JitX64][Thumb][Thumb32]") {
                          const auto n = Common::Bits<16, 19>(inst);
                          return m == n && d != 15 && m != 15;
                      }),
+        ThumbInstGen("111110101001nnnn1111dddd1010mmmm", // RBIT
+                     [](u32 inst) {
+                         const auto d = Common::Bits<8, 11>(inst);
+                         const auto m = Common::Bits<0, 3>(inst);
+                         const auto n = Common::Bits<16, 19>(inst);
+                         return m == n && d != 15 && m != 15;
+                     }),
         ThumbInstGen("111110101001nnnn1111dddd1011mmmm", // REVSH
                      [](u32 inst) {
                          const auto d = Common::Bits<8, 11>(inst);

--- a/tests/A32/fuzz_thumb.cpp
+++ b/tests/A32/fuzz_thumb.cpp
@@ -376,6 +376,13 @@ TEST_CASE("Fuzz Thumb32 instructions set", "[JitX64][Thumb][Thumb32]") {
                          const auto n = Common::Bits<16, 19>(inst);
                          return m == n && d != 15 && m != 15;
                      }),
+        ThumbInstGen("111110101001nnnn1111dddd1000mmmm", // REV
+                     [](u32 inst) {
+                         const auto d = Common::Bits<8, 11>(inst);
+                         const auto m = Common::Bits<0, 3>(inst);
+                         const auto n = Common::Bits<16, 19>(inst);
+                         return m == n && d != 15 && m != 15;
+                     }),
         ThumbInstGen("111110101001nnnn1111dddd1001mmmm", // REV16
                      [](u32 inst) {
                          const auto d = Common::Bits<8, 11>(inst);

--- a/tests/A32/fuzz_thumb.cpp
+++ b/tests/A32/fuzz_thumb.cpp
@@ -369,6 +369,13 @@ TEST_CASE("Fuzz Thumb32 instructions set", "[JitX64][Thumb][Thumb32]") {
                          const auto n = Common::Bits<16, 19>(inst);
                          return m == n && d != 15 && m != 15;
                      }),
+        ThumbInstGen("111110101000nnnn1111dddd1000mmmm", // QADD
+                     [](u32 inst) {
+                         const auto d = Common::Bits<8, 11>(inst);
+                         const auto m = Common::Bits<0, 3>(inst);
+                         const auto n = Common::Bits<16, 19>(inst);
+                         return d != 15 && m != 15 && n != 15;
+                     }),
         ThumbInstGen("111110101000nnnn1111dddd1001mmmm", // QDADD
                      [](u32 inst) {
                          const auto d = Common::Bits<8, 11>(inst);

--- a/tests/A32/fuzz_thumb.cpp
+++ b/tests/A32/fuzz_thumb.cpp
@@ -369,6 +369,13 @@ TEST_CASE("Fuzz Thumb32 instructions set", "[JitX64][Thumb][Thumb32]") {
                          const auto n = Common::Bits<16, 19>(inst);
                          return m == n && d != 15 && m != 15;
                      }),
+        ThumbInstGen("111110101010nnnn1111dddd1000mmmm",
+                     [](u32 inst) {
+                         const auto d = Common::Bits<8, 11>(inst);
+                         const auto m = Common::Bits<0, 3>(inst);
+                         const auto n = Common::Bits<16, 19>(inst);
+                         return d != 15 && m != 15 && n != 15;
+                     }),
     };
 
     const auto instruction_select = [&]() -> u32 {

--- a/tests/A32/fuzz_thumb.cpp
+++ b/tests/A32/fuzz_thumb.cpp
@@ -369,7 +369,14 @@ TEST_CASE("Fuzz Thumb32 instructions set", "[JitX64][Thumb][Thumb32]") {
                          const auto n = Common::Bits<16, 19>(inst);
                          return m == n && d != 15 && m != 15;
                      }),
-        ThumbInstGen("111110101010nnnn1111dddd1000mmmm",
+        ThumbInstGen("111110101001nnnn1111dddd1011mmmm", // REVSH
+                     [](u32 inst) {
+                         const auto d = Common::Bits<8, 11>(inst);
+                         const auto m = Common::Bits<0, 3>(inst);
+                         const auto n = Common::Bits<16, 19>(inst);
+                         return m == n && d != 15 && m != 15;
+                     }),
+        ThumbInstGen("111110101010nnnn1111dddd1000mmmm", // SEL
                      [](u32 inst) {
                          const auto d = Common::Bits<8, 11>(inst);
                          const auto m = Common::Bits<0, 3>(inst);

--- a/tests/A32/fuzz_thumb.cpp
+++ b/tests/A32/fuzz_thumb.cpp
@@ -369,6 +369,20 @@ TEST_CASE("Fuzz Thumb32 instructions set", "[JitX64][Thumb][Thumb32]") {
                          const auto n = Common::Bits<16, 19>(inst);
                          return m == n && d != 15 && m != 15;
                      }),
+        ThumbInstGen("111110101000nnnn1111dddd1001mmmm", // QDADD
+                     [](u32 inst) {
+                         const auto d = Common::Bits<8, 11>(inst);
+                         const auto m = Common::Bits<0, 3>(inst);
+                         const auto n = Common::Bits<16, 19>(inst);
+                         return d != 15 && m != 15 && n != 15;
+                     }),
+        ThumbInstGen("111110101000nnnn1111dddd1011mmmm", // QDSUB
+                     [](u32 inst) {
+                         const auto d = Common::Bits<8, 11>(inst);
+                         const auto m = Common::Bits<0, 3>(inst);
+                         const auto n = Common::Bits<16, 19>(inst);
+                         return d != 15 && m != 15 && n != 15;
+                     }),
         ThumbInstGen("111110101001nnnn1111dddd1010mmmm", // RBIT
                      [](u32 inst) {
                          const auto d = Common::Bits<8, 11>(inst);

--- a/tests/A32/fuzz_thumb.cpp
+++ b/tests/A32/fuzz_thumb.cpp
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <cstring>
 #include <functional>
+#include <string_view>
 #include <tuple>
 
 #include <catch.hpp>
@@ -41,11 +42,13 @@ using WriteRecords = std::map<u32, u8>;
 
 struct ThumbInstGen final {
 public:
-    ThumbInstGen(const char* format, std::function<bool(u16)> is_valid = [](u16){ return true; }) : is_valid(is_valid) {
-        REQUIRE(strlen(format) == 16);
+    ThumbInstGen(std::string_view format, std::function<bool(u32)> is_valid = [](u32){ return true; }) : is_valid(is_valid) {
+        REQUIRE((format.size() == 16 || format.size() == 32));
 
-        for (int i = 0; i < 16; i++) {
-            const u16 bit = 1 << (15 - i);
+        const auto bit_size = format.size();
+
+        for (size_t i = 0; i < bit_size; i++) {
+            const u32 bit = 1U << (bit_size - 1 - i);
             switch (format[i]) {
             case '0':
                 mask |= bit;
@@ -60,11 +63,25 @@ public:
             }
         }
     }
-    u16 Generate() const {
-        u16 inst;
+
+    u16 Generate16() const {
+        u32 inst;
 
         do {
-            const u16 random = RandInt<u16>(0, 0xFFFF);
+            const auto random = RandInt<u16>(0, 0xFFFF);
+            inst = bits | (random & ~mask);
+        } while (!is_valid(inst));
+
+        ASSERT((inst & mask) == bits);
+
+        return static_cast<u16>(inst);
+    }
+
+    u32 Generate32() const {
+        u32 inst;
+
+        do {
+            const auto random = RandInt<u32>(0, 0xFFFFFFFF);
             inst = bits | (random & ~mask);
         } while (!is_valid(inst));
 
@@ -72,10 +89,11 @@ public:
 
         return inst;
     }
+
 private:
-    u16 bits = 0;
-    u16 mask = 0;
-    std::function<bool(u16)> is_valid;
+    u32 bits = 0;
+    u32 mask = 0;
+    std::function<bool(u32)> is_valid;
 };
 
 static bool DoesBehaviorMatch(const A32Unicorn<ThumbTestEnv>& uni, const A32::Jit& jit,
@@ -179,7 +197,7 @@ static void RunInstance(size_t run_number, ThumbTestEnv& test_env, A32Unicorn<Th
     }
 }
 
-void FuzzJitThumb(const size_t instruction_count, const size_t instructions_to_execute_count, const size_t run_count, const std::function<u16()> instruction_generator) {
+void FuzzJitThumb16(const size_t instruction_count, const size_t instructions_to_execute_count, const size_t run_count, const std::function<u16()> instruction_generator) {
     ThumbTestEnv test_env;
 
     // Prepare memory.
@@ -201,6 +219,36 @@ void FuzzJitThumb(const size_t instruction_count, const size_t instructions_to_e
     }
 }
 
+void FuzzJitThumb32(const size_t instruction_count, const size_t instructions_to_execute_count, const size_t run_count, const std::function<u32()> instruction_generator) {
+    ThumbTestEnv test_env;
+
+    // Prepare memory.
+    // A Thumb-32 instruction is 32-bits so we multiply our count
+    test_env.code_mem.resize(instruction_count * 2 + 1);
+    test_env.code_mem.back() = 0xE7FE; // b +#0
+
+    // Prepare test subjects
+    A32Unicorn uni{test_env};
+    A32::Jit jit{GetUserConfig(&test_env)};
+
+    for (size_t run_number = 0; run_number < run_count; run_number++) {
+        ThumbTestEnv::RegisterArray initial_regs;
+        std::generate_n(initial_regs.begin(), initial_regs.size() - 1, []{ return RandInt<u32>(0, 0xFFFFFFFF); });
+        initial_regs[15] = 0;
+
+        for (size_t i = 0; i < instruction_count; i++) {
+            const auto instruction = instruction_generator();
+            const auto first_halfword = static_cast<u16>(Common::Bits<0, 15>(instruction));
+            const auto second_halfword = static_cast<u16>(Common::Bits<16, 31>(instruction));
+
+            test_env.code_mem[i * 2 + 0] = second_halfword;
+            test_env.code_mem[i * 2 + 1] = first_halfword;
+        }
+
+        RunInstance(run_number, test_env, uni, jit, initial_regs, instruction_count, instructions_to_execute_count);
+    }
+}
+
 TEST_CASE("Fuzz Thumb instructions set 1", "[JitX64][Thumb]") {
     const std::array instructions = {
         ThumbInstGen("00000xxxxxxxxxxx"), // LSL <Rd>, <Rm>, #<imm5>
@@ -212,9 +260,9 @@ TEST_CASE("Fuzz Thumb instructions set 1", "[JitX64][Thumb]") {
         ThumbInstGen("010000ooooxxxxxx"), // Data Processing
         ThumbInstGen("010001000hxxxxxx"), // ADD (high registers)
         ThumbInstGen("0100010101xxxxxx",  // CMP (high registers)
-                     [](u16 inst){ return Common::Bits<3, 5>(inst) != 0b111; }), // R15 is UNPREDICTABLE
+                     [](u32 inst){ return Common::Bits<3, 5>(inst) != 0b111; }), // R15 is UNPREDICTABLE
         ThumbInstGen("0100010110xxxxxx",  // CMP (high registers)
-                     [](u16 inst){ return Common::Bits<0, 2>(inst) != 0b111; }), // R15 is UNPREDICTABLE
+                     [](u32 inst){ return Common::Bits<0, 2>(inst) != 0b111; }), // R15 is UNPREDICTABLE
         ThumbInstGen("010001100hxxxxxx"), // MOV (high registers)
         ThumbInstGen("10110000oxxxxxxx"), // Adjust stack pointer
         ThumbInstGen("10110010ooxxxxxx"), // SXT/UXT
@@ -227,11 +275,11 @@ TEST_CASE("Fuzz Thumb instructions set 1", "[JitX64][Thumb]") {
         ThumbInstGen("1000xxxxxxxxxxxx"), // LDRH/STRH Rd, [Rn, #offset]
         ThumbInstGen("1001xxxxxxxxxxxx"), // LDR/STR Rd, [SP, #]
         ThumbInstGen("1011010xxxxxxxxx",  // PUSH
-                     [](u16 inst){ return Common::Bits<0, 7>(inst) != 0; }), // Empty reg_list is UNPREDICTABLE
+                     [](u32 inst){ return Common::Bits<0, 7>(inst) != 0; }), // Empty reg_list is UNPREDICTABLE
         ThumbInstGen("10111100xxxxxxxx",  // POP (P = 0)
-                     [](u16 inst){ return Common::Bits<0, 7>(inst) != 0; }), // Empty reg_list is UNPREDICTABLE
+                     [](u32 inst){ return Common::Bits<0, 7>(inst) != 0; }), // Empty reg_list is UNPREDICTABLE
         ThumbInstGen("1100xxxxxxxxxxxx", // STMIA/LDMIA
-                     [](u16 inst) {
+                     [](u32 inst) {
                          // Ensure that the architecturally undefined case of
                          // the base register being within the list isn't hit.
                          const u32 rn = Common::Bits<8, 10>(inst);
@@ -247,24 +295,24 @@ TEST_CASE("Fuzz Thumb instructions set 1", "[JitX64][Thumb]") {
     };
 
     const auto instruction_select = [&]() -> u16 {
-        size_t inst_index = RandInt<size_t>(0, instructions.size() - 1);
+        const auto inst_index = RandInt<size_t>(0, instructions.size() - 1);
 
-        return instructions[inst_index].Generate();
+        return instructions[inst_index].Generate16();
     };
 
     SECTION("single instructions") {
-        FuzzJitThumb(1, 2, 10000, instruction_select);
+        FuzzJitThumb16(1, 2, 10000, instruction_select);
     }
 
     SECTION("short blocks") {
-        FuzzJitThumb(5, 6, 3000, instruction_select);
+        FuzzJitThumb16(5, 6, 3000, instruction_select);
     }
 
     // TODO: Test longer blocks when Unicorn can consistently
     //       run these without going into an infinite loop.
 #if 0
     SECTION("long blocks") {
-        FuzzJitThumb(1024, 1025, 1000, instruction_select);
+        FuzzJitThumb16(1024, 1025, 1000, instruction_select);
     }
 #endif
 }
@@ -278,7 +326,7 @@ TEST_CASE("Fuzz Thumb instructions set 2 (affects PC)", "[JitX64][Thumb]") {
         //       must not be address<1:0> == '10'.
 #if 0
         ThumbInstGen("01000111xmmmm000",  // BLX/BX
-                     [](u16 inst){
+                     [](u32 inst){
                          const u32 Rm = Common::Bits<3, 6>(inst);
                          return Rm != 15;
                      }),
@@ -288,7 +336,7 @@ TEST_CASE("Fuzz Thumb instructions set 2 (affects PC)", "[JitX64][Thumb]") {
         ThumbInstGen("01000100h0xxxxxx"), // ADD (high registers)
         ThumbInstGen("01000110h0xxxxxx"), // MOV (high registers)
         ThumbInstGen("1101ccccxxxxxxxx",  // B<cond>
-                     [](u16 inst){
+                     [](u32 inst){
                          const u32 c = Common::Bits<9, 12>(inst);
                          return c < 0b1110; // Don't want SWI or undefined instructions.
                      }),
@@ -304,12 +352,38 @@ TEST_CASE("Fuzz Thumb instructions set 2 (affects PC)", "[JitX64][Thumb]") {
     };
 
     const auto instruction_select = [&]() -> u16 {
-        size_t inst_index = RandInt<size_t>(0, instructions.size() - 1);
+        const auto inst_index = RandInt<size_t>(0, instructions.size() - 1);
 
-        return instructions[inst_index].Generate();
+        return instructions[inst_index].Generate16();
     };
 
-    FuzzJitThumb(1, 1, 10000, instruction_select);
+    FuzzJitThumb16(1, 1, 10000, instruction_select);
+}
+
+TEST_CASE("Fuzz Thumb32 instructions set", "[JitX64][Thumb][Thumb32]") {
+    const std::array instructions = {
+        ThumbInstGen("111110101011nnnn1111dddd1000mmmm", // CLZ
+                     [](u32 inst) {
+                         const auto d = Common::Bits<8, 11>(inst);
+                         const auto m = Common::Bits<0, 3>(inst);
+                         const auto n = Common::Bits<16, 19>(inst);
+                         return m == n && d != 15 && m != 15;
+                     }),
+    };
+
+    const auto instruction_select = [&]() -> u32 {
+        const auto inst_index = RandInt<size_t>(0, instructions.size() - 1);
+
+        return instructions[inst_index].Generate32();
+    };
+
+    SECTION("single instructions") {
+        FuzzJitThumb32(1, 2, 10000, instruction_select);
+    }
+
+    SECTION("short blocks") {
+        FuzzJitThumb32(5, 6, 3000, instruction_select);
+    }
 }
 
 TEST_CASE("Verify fix for off by one error in MemoryRead32 worked", "[Thumb]") {


### PR DESCRIPTION
Begins the addition of Thumb-2 instructions and extends the Thumb-1 harness to allow for Thumb-2 instruction generation and fuzzing.