### PR TITLE
thumb32: Implement MLA/MLS/MUL/USAD8/USADA8

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -152,6 +152,7 @@ if ("A32" IN_LIST DYNARMIC_FRONTENDS)
         frontend/A32/translate/impl/thumb16.cpp
         frontend/A32/translate/impl/thumb32.cpp
         frontend/A32/translate/impl/thumb32_misc.cpp
+        frontend/A32/translate/impl/thumb32_multiply.cpp
         frontend/A32/translate/impl/thumb32_parallel.cpp
         frontend/A32/translate/impl/translate_arm.h
         frontend/A32/translate/impl/translate_thumb.h

--- a/src/frontend/A32/decoder/thumb32.inc
+++ b/src/frontend/A32/decoder/thumb32.inc
@@ -261,7 +261,7 @@ INST(thumb32_SEL,            "SEL",                      "111110101010nnnn1111dd
 INST(thumb32_CLZ,            "CLZ",                      "111110101011nnnn1111dddd1000mmmm")
 
 // Multiply, Multiply Accumulate, and Absolute Difference
-//INST(thumb32_MUL,            "MUL",                      "111110110000----1111----0000----")
+INST(thumb32_MUL,            "MUL",                      "111110110000nnnn1111dddd0000mmmm")
 //INST(thumb32_MLA,            "MLA",                      "111110110000------------0000----")
 //INST(thumb32_MLS,            "MLS",                      "111110110000------------0001----")
 //INST(thumb32_SMULXY,         "SMULXY",                   "111110110001----1111----00------")

--- a/src/frontend/A32/decoder/thumb32.inc
+++ b/src/frontend/A32/decoder/thumb32.inc
@@ -262,7 +262,7 @@ INST(thumb32_CLZ,            "CLZ",                      "111110101011nnnn1111dd
 
 // Multiply, Multiply Accumulate, and Absolute Difference
 INST(thumb32_MUL,            "MUL",                      "111110110000nnnn1111dddd0000mmmm")
-//INST(thumb32_MLA,            "MLA",                      "111110110000------------0000----")
+INST(thumb32_MLA,            "MLA",                      "111110110000nnnnaaaadddd0000mmmm")
 //INST(thumb32_MLS,            "MLS",                      "111110110000------------0001----")
 //INST(thumb32_SMULXY,         "SMULXY",                   "111110110001----1111----00------")
 //INST(thumb32_SMLAXY,         "SMLAXY",                   "111110110001------------00------")

--- a/src/frontend/A32/decoder/thumb32.inc
+++ b/src/frontend/A32/decoder/thumb32.inc
@@ -263,7 +263,7 @@ INST(thumb32_CLZ,            "CLZ",                      "111110101011nnnn1111dd
 // Multiply, Multiply Accumulate, and Absolute Difference
 INST(thumb32_MUL,            "MUL",                      "111110110000nnnn1111dddd0000mmmm")
 INST(thumb32_MLA,            "MLA",                      "111110110000nnnnaaaadddd0000mmmm")
-//INST(thumb32_MLS,            "MLS",                      "111110110000------------0001----")
+INST(thumb32_MLS,            "MLS",                      "111110110000nnnnaaaadddd0001mmmm")
 //INST(thumb32_SMULXY,         "SMULXY",                   "111110110001----1111----00------")
 //INST(thumb32_SMLAXY,         "SMLAXY",                   "111110110001------------00------")
 //INST(thumb32_SMUAD,          "SMUAD",                    "111110110010----1111----000-----")

--- a/src/frontend/A32/decoder/thumb32.inc
+++ b/src/frontend/A32/decoder/thumb32.inc
@@ -276,7 +276,7 @@ INST(thumb32_MLS,            "MLS",                      "111110110000nnnnaaaadd
 //INST(thumb32_SMMLA,          "SMMLA",                    "111110110101------------000-----")
 //INST(thumb32_SMMLS,          "SMMLS",                    "111110110110------------000-----")
 INST(thumb32_USAD8,          "USAD8",                    "111110110111nnnn1111dddd0000mmmm")
-//INST(thumb32_USADA8,         "USADA8",                   "111110110111------------0000----")
+INST(thumb32_USADA8,         "USADA8",                   "111110110111nnnnaaaadddd0000mmmm")
 
 // Long Multiply, Long Multiply Accumulate, and Divide
 //INST(thumb32_SMULL,          "SMULL",                    "111110111000------------0000----")

--- a/src/frontend/A32/decoder/thumb32.inc
+++ b/src/frontend/A32/decoder/thumb32.inc
@@ -275,7 +275,7 @@ INST(thumb32_MLS,            "MLS",                      "111110110000nnnnaaaadd
 //INST(thumb32_SMMUL,          "SMMUL",                    "111110110101----1111----000-----")
 //INST(thumb32_SMMLA,          "SMMLA",                    "111110110101------------000-----")
 //INST(thumb32_SMMLS,          "SMMLS",                    "111110110110------------000-----")
-//INST(thumb32_USAD8,          "USAD8",                    "111110110111----1111----0000----")
+INST(thumb32_USAD8,          "USAD8",                    "111110110111nnnn1111dddd0000mmmm")
 //INST(thumb32_USADA8,         "USADA8",                   "111110110111------------0000----")
 
 // Long Multiply, Long Multiply Accumulate, and Divide

--- a/src/frontend/A32/translate/impl/thumb32_multiply.cpp
+++ b/src/frontend/A32/translate/impl/thumb32_multiply.cpp
@@ -48,4 +48,17 @@ bool ThumbTranslatorVisitor::thumb32_MUL(Reg n, Reg d, Reg m) {
     return true;
 }
 
+bool ThumbTranslatorVisitor::thumb32_USAD8(Reg n, Reg d, Reg m) {
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
+        return UnpredictableInstruction();
+    }
+
+    const auto reg_m = ir.GetRegister(m);
+    const auto reg_n = ir.GetRegister(n);
+    const auto result = ir.PackedAbsDiffSumS8(reg_n, reg_m);
+
+    ir.SetRegister(d, result);
+    return true;
+}
+
 } // namespace Dynarmic::A32

--- a/src/frontend/A32/translate/impl/thumb32_multiply.cpp
+++ b/src/frontend/A32/translate/impl/thumb32_multiply.cpp
@@ -7,6 +7,20 @@
 
 namespace Dynarmic::A32 {
 
+bool ThumbTranslatorVisitor::thumb32_MLA(Reg n, Reg a, Reg d, Reg m) {
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
+        return UnpredictableInstruction();
+    }
+
+    const auto reg_a = ir.GetRegister(a);
+    const auto reg_m = ir.GetRegister(m);
+    const auto reg_n = ir.GetRegister(n);
+    const auto result = ir.Add(ir.Mul(reg_n, reg_m), reg_a);
+
+    ir.SetRegister(d, result);
+    return true;
+}
+
 bool ThumbTranslatorVisitor::thumb32_MUL(Reg n, Reg d, Reg m) {
     if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();

--- a/src/frontend/A32/translate/impl/thumb32_multiply.cpp
+++ b/src/frontend/A32/translate/impl/thumb32_multiply.cpp
@@ -1,0 +1,23 @@
+/* This file is part of the dynarmic project.
+ * Copyright (c) 2021 MerryMage
+ * SPDX-License-Identifier: 0BSD
+ */
+
+#include "frontend/A32/translate/impl/translate_thumb.h"
+
+namespace Dynarmic::A32 {
+
+bool ThumbTranslatorVisitor::thumb32_MUL(Reg n, Reg d, Reg m) {
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
+        return UnpredictableInstruction();
+    }
+
+    const auto reg_m = ir.GetRegister(m);
+    const auto reg_n = ir.GetRegister(n);
+    const auto result = ir.Mul(reg_n, reg_m);
+
+    ir.SetRegister(d, result);
+    return true;
+}
+
+} // namespace Dynarmic::A32

--- a/src/frontend/A32/translate/impl/thumb32_multiply.cpp
+++ b/src/frontend/A32/translate/impl/thumb32_multiply.cpp
@@ -21,6 +21,20 @@ bool ThumbTranslatorVisitor::thumb32_MLA(Reg n, Reg a, Reg d, Reg m) {
     return true;
 }
 
+bool ThumbTranslatorVisitor::thumb32_MLS(Reg n, Reg a, Reg d, Reg m) {
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
+        return UnpredictableInstruction();
+    }
+
+    const auto reg_a = ir.GetRegister(a);
+    const auto reg_m = ir.GetRegister(m);
+    const auto reg_n = ir.GetRegister(n);
+    const auto result = ir.Sub(reg_a, ir.Mul(reg_n, reg_m));
+
+    ir.SetRegister(d, result);
+    return true;
+}
+
 bool ThumbTranslatorVisitor::thumb32_MUL(Reg n, Reg d, Reg m) {
     if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
         return UnpredictableInstruction();

--- a/src/frontend/A32/translate/impl/thumb32_multiply.cpp
+++ b/src/frontend/A32/translate/impl/thumb32_multiply.cpp
@@ -61,4 +61,19 @@ bool ThumbTranslatorVisitor::thumb32_USAD8(Reg n, Reg d, Reg m) {
     return true;
 }
 
+bool ThumbTranslatorVisitor::thumb32_USADA8(Reg n, Reg a, Reg d, Reg m) {
+    if (d == Reg::PC || n == Reg::PC || m == Reg::PC) {
+        return UnpredictableInstruction();
+    }
+
+    const auto reg_a = ir.GetRegister(a);
+    const auto reg_m = ir.GetRegister(m);
+    const auto reg_n = ir.GetRegister(n);
+    const auto tmp = ir.PackedAbsDiffSumS8(reg_n, reg_m);
+    const auto result = ir.AddWithCarry(reg_a, tmp, ir.Imm1(0));
+
+    ir.SetRegister(d, result.result);
+    return true;
+}
+
 } // namespace Dynarmic::A32

--- a/src/frontend/A32/translate/impl/translate_thumb.h
+++ b/src/frontend/A32/translate/impl/translate_thumb.h
@@ -130,6 +130,7 @@ struct ThumbTranslatorVisitor final {
 
     // thumb32 multiply instructions
     bool thumb32_MLA(Reg n, Reg a, Reg d, Reg m);
+    bool thumb32_MLS(Reg n, Reg a, Reg d, Reg m);
     bool thumb32_MUL(Reg n, Reg d, Reg m);
 
     // thumb32 parallel add/sub instructions

--- a/src/frontend/A32/translate/impl/translate_thumb.h
+++ b/src/frontend/A32/translate/impl/translate_thumb.h
@@ -133,6 +133,7 @@ struct ThumbTranslatorVisitor final {
     bool thumb32_MLS(Reg n, Reg a, Reg d, Reg m);
     bool thumb32_MUL(Reg n, Reg d, Reg m);
     bool thumb32_USAD8(Reg n, Reg d, Reg m);
+    bool thumb32_USADA8(Reg n, Reg a, Reg d, Reg m);
 
     // thumb32 parallel add/sub instructions
     bool thumb32_SADD8(Reg n, Reg d, Reg m);

--- a/src/frontend/A32/translate/impl/translate_thumb.h
+++ b/src/frontend/A32/translate/impl/translate_thumb.h
@@ -129,6 +129,7 @@ struct ThumbTranslatorVisitor final {
     bool thumb32_SEL(Reg n, Reg d, Reg m);
 
     // thumb32 multiply instructions
+    bool thumb32_MLA(Reg n, Reg a, Reg d, Reg m);
     bool thumb32_MUL(Reg n, Reg d, Reg m);
 
     // thumb32 parallel add/sub instructions

--- a/src/frontend/A32/translate/impl/translate_thumb.h
+++ b/src/frontend/A32/translate/impl/translate_thumb.h
@@ -128,6 +128,9 @@ struct ThumbTranslatorVisitor final {
     bool thumb32_REVSH(Reg n, Reg d, Reg m);
     bool thumb32_SEL(Reg n, Reg d, Reg m);
 
+    // thumb32 multiply instructions
+    bool thumb32_MUL(Reg n, Reg d, Reg m);
+
     // thumb32 parallel add/sub instructions
     bool thumb32_SADD8(Reg n, Reg d, Reg m);
     bool thumb32_SADD16(Reg n, Reg d, Reg m);

--- a/src/frontend/A32/translate/impl/translate_thumb.h
+++ b/src/frontend/A32/translate/impl/translate_thumb.h
@@ -132,6 +132,7 @@ struct ThumbTranslatorVisitor final {
     bool thumb32_MLA(Reg n, Reg a, Reg d, Reg m);
     bool thumb32_MLS(Reg n, Reg a, Reg d, Reg m);
     bool thumb32_MUL(Reg n, Reg d, Reg m);
+    bool thumb32_USAD8(Reg n, Reg d, Reg m);
 
     // thumb32 parallel add/sub instructions
     bool thumb32_SADD8(Reg n, Reg d, Reg m);


### PR DESCRIPTION
Migrates over the five basic multiplication instructions. Will implement the others in a follow-up PR to keep this one small.