### PR TITLE
thumb32: Implement MOVT/MOVW 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -157,6 +157,7 @@ if ("A32" IN_LIST DYNARMIC_FRONTENDS)
         frontend/A32/translate/impl/thumb32_control.cpp
         frontend/A32/translate/impl/thumb32_data_processing_register.cpp
         frontend/A32/translate/impl/thumb32_data_processing_modified_immediate.cpp
+        frontend/A32/translate/impl/thumb32_data_processing_plain_binary_immediate.cpp
         frontend/A32/translate/impl/thumb32_long_multiply.cpp
         frontend/A32/translate/impl/thumb32_misc.cpp
         frontend/A32/translate/impl/thumb32_multiply.cpp

--- a/src/frontend/A32/decoder/thumb32.inc
+++ b/src/frontend/A32/decoder/thumb32.inc
@@ -73,7 +73,7 @@ INST(thumb32_EOR_imm,        "EOR (imm)",                "11110v00100Snnnn0vvvdd
 // Data Processing (Plain Binary Immediate)
 //INST(thumb32_ADR,            "ADR",                      "11110-10000011110---------------")
 //INST(thumb32_ADD_imm_2,      "ADD (imm)",                "11110-100000----0---------------")
-//INST(thumb32_MOVW_imm,       "MOVW (imm)",               "11110-100100----0---------------")
+INST(thumb32_MOVW_imm,       "MOVW (imm)",               "11110i100100iiii0iiiddddiiiiiiii")
 //INST(thumb32_ADR,            "ADR",                      "11110-10101011110---------------")
 //INST(thumb32_SUB_imm_2,      "SUB (imm)",                "11110-101010----0---------------")
 INST(thumb32_MOVT,           "MOVT",                     "11110i101100iiii0iiiddddiiiiiiii")

--- a/src/frontend/A32/decoder/thumb32.inc
+++ b/src/frontend/A32/decoder/thumb32.inc
@@ -76,7 +76,7 @@ INST(thumb32_EOR_imm,        "EOR (imm)",                "11110v00100Snnnn0vvvdd
 //INST(thumb32_MOVW_imm,       "MOVW (imm)",               "11110-100100----0---------------")
 //INST(thumb32_ADR,            "ADR",                      "11110-10101011110---------------")
 //INST(thumb32_SUB_imm_2,      "SUB (imm)",                "11110-101010----0---------------")
-//INST(thumb32_MOVT,           "MOVT",                     "11110-101100----0---------------")
+INST(thumb32_MOVT,           "MOVT",                     "11110i101100iiii0iiiddddiiiiiiii")
 //INST(thumb32_SSAT,           "SSAT",                     "11110-110000----0---------------")
 //INST(thumb32_SSAT16,         "SSAT16",                   "11110-110010----0000----00------")
 //INST(thumb32_SSAT,           "SSAT",                     "11110-110010----0---------------")

--- a/src/frontend/A32/translate/impl/thumb32_data_processing_plain_binary_immediate.cpp
+++ b/src/frontend/A32/translate/impl/thumb32_data_processing_plain_binary_immediate.cpp
@@ -1,0 +1,23 @@
+/* This file is part of the dynarmic project.
+ * Copyright (c) 2021 MerryMage
+ * SPDX-License-Identifier: 0BSD
+ */
+
+#include "frontend/A32/translate/impl/translate_thumb.h"
+
+namespace Dynarmic::A32 {
+
+bool ThumbTranslatorVisitor::thumb32_MOVT(Imm<1> imm1, Imm<4> imm4, Imm<3> imm3, Reg d, Imm<8> imm8) {
+    if (d == Reg::PC) {
+        return UnpredictableInstruction();
+    }
+
+    const IR::U32 imm16 = ir.Imm32(concatenate(imm4, imm1, imm3, imm8).ZeroExtend() << 16);
+    const IR::U32 operand = ir.GetRegister(d);
+    const IR::U32 result = ir.Or(ir.And(operand, ir.Imm32(0x0000FFFFU)), imm16);
+
+    ir.SetRegister(d, result);
+    return true;
+}
+
+} // namespace Dynarmic::A32

--- a/src/frontend/A32/translate/impl/thumb32_data_processing_plain_binary_immediate.cpp
+++ b/src/frontend/A32/translate/impl/thumb32_data_processing_plain_binary_immediate.cpp
@@ -20,4 +20,15 @@ bool ThumbTranslatorVisitor::thumb32_MOVT(Imm<1> imm1, Imm<4> imm4, Imm<3> imm3,
     return true;
 }
 
+bool ThumbTranslatorVisitor::thumb32_MOVW_imm(Imm<1> imm1, Imm<4> imm4, Imm<3> imm3, Reg d, Imm<8> imm8) {
+    if (d == Reg::PC) {
+        return UnpredictableInstruction();
+    }
+
+    const IR::U32 imm = ir.Imm32(concatenate(imm4, imm1, imm3, imm8).ZeroExtend());
+
+    ir.SetRegister(d, imm);
+    return true;
+}
+
 } // namespace Dynarmic::A32

--- a/src/frontend/A32/translate/impl/translate_thumb.h
+++ b/src/frontend/A32/translate/impl/translate_thumb.h
@@ -161,6 +161,7 @@ struct ThumbTranslatorVisitor final {
 
     // thumb32 data processing (plain binary immediate) instructions.
     bool thumb32_MOVT(Imm<1> imm1, Imm<4> imm4, Imm<3> imm3, Reg d, Imm<8> imm8);
+    bool thumb32_MOVW_imm(Imm<1> imm1, Imm<4> imm4, Imm<3> imm3, Reg d, Imm<8> imm8);
 
     // thumb32 miscellaneous control instructions
     bool thumb32_UDF();

--- a/src/frontend/A32/translate/impl/translate_thumb.h
+++ b/src/frontend/A32/translate/impl/translate_thumb.h
@@ -159,6 +159,9 @@ struct ThumbTranslatorVisitor final {
     bool thumb32_TEQ_imm(Imm<1> i, Reg n, Imm<3> imm3, Imm<8> imm8);
     bool thumb32_EOR_imm(Imm<1> i, bool S, Reg n, Imm<3> imm3, Reg d, Imm<8> imm8);
 
+    // thumb32 data processing (plain binary immediate) instructions.
+    bool thumb32_MOVT(Imm<1> imm1, Imm<4> imm4, Imm<3> imm3, Reg d, Imm<8> imm8);
+
     // thumb32 miscellaneous control instructions
     bool thumb32_UDF();
 


### PR DESCRIPTION
Gets the plain binary immediate files in place. Will follow this up by doing the saturation instructions within the same category