### PR TITLE
thumb32: Implement plain binary immediate ADR variants

### DIFF
--- a/src/frontend/A32/decoder/thumb32.inc
+++ b/src/frontend/A32/decoder/thumb32.inc
@@ -66,10 +66,10 @@ INST(thumb32_SUB_imm_1,      "SUB (imm)",                "11110v01101Snnnn0vvvdd
 INST(thumb32_RSB_imm,        "RSB (imm)",                "11110v01110Snnnn0vvvddddvvvvvvvv")
 
 // Data Processing (Plain Binary Immediate)
-//INST(thumb32_ADR,            "ADR",                      "11110-10000011110---------------")
+INST(thumb32_ADR_t3,         "ADR",                      "11110i10000011110iiiddddiiiiiiii")
 INST(thumb32_ADD_imm_2,      "ADD (imm)",                "11110i10000011010iiiddddiiiiiiii")
 INST(thumb32_MOVW_imm,       "MOVW (imm)",               "11110i100100iiii0iiiddddiiiiiiii")
-//INST(thumb32_ADR,            "ADR",                      "11110-10101011110---------------")
+INST(thumb32_ADR_t2,         "ADR",                      "11110i10101011110iiiddddiiiiiiii")
 INST(thumb32_SUB_imm_2,      "SUB (imm)",                "11110i10101011010iiiddddiiiiiiii")
 INST(thumb32_MOVT,           "MOVT",                     "11110i101100iiii0iiiddddiiiiiiii")
 INST(thumb32_UDF,            "Invalid decoding",         "11110011-010----0000----0001----")

--- a/src/frontend/A32/translate/impl/thumb32_data_processing_plain_binary_immediate.cpp
+++ b/src/frontend/A32/translate/impl/thumb32_data_processing_plain_binary_immediate.cpp
@@ -52,6 +52,30 @@ static bool Saturation16(ThumbTranslatorVisitor& v, Reg n, Reg d, size_t saturat
     return true;
 }
 
+bool ThumbTranslatorVisitor::thumb32_ADR_t2(Imm<1> imm1, Imm<3> imm3, Reg d, Imm<8> imm8) {
+    if (d == Reg::PC) {
+        return UnpredictableInstruction();
+    }
+
+    const auto imm32 = concatenate(imm1, imm3, imm8).ZeroExtend();
+    const auto result = ir.AlignPC(4) - imm32;
+
+    ir.SetRegister(d, ir.Imm32(result));
+    return true;
+}
+
+bool ThumbTranslatorVisitor::thumb32_ADR_t3(Imm<1> imm1, Imm<3> imm3, Reg d, Imm<8> imm8) {
+    if (d == Reg::PC) {
+        return UnpredictableInstruction();
+    }
+
+    const auto imm32 = concatenate(imm1, imm3, imm8).ZeroExtend();
+    const auto result = ir.AlignPC(4) + imm32;
+
+    ir.SetRegister(d, ir.Imm32(result));
+    return true;
+}
+
 bool ThumbTranslatorVisitor::thumb32_ADD_imm_2(Imm<1> imm1, Imm<3> imm3, Reg d, Imm<8> imm8) {
     if (d == Reg::PC) {
         return UnpredictableInstruction();

--- a/src/frontend/A32/translate/impl/translate_thumb.h
+++ b/src/frontend/A32/translate/impl/translate_thumb.h
@@ -209,6 +209,8 @@ struct ThumbTranslatorVisitor final {
     bool thumb32_RSB_imm(Imm<1> i, bool S, Reg n, Imm<3> imm3, Reg d, Imm<8> imm8);
 
     // thumb32 data processing (plain binary immediate) instructions.
+    bool thumb32_ADR_t2(Imm<1> imm1, Imm<3> imm3, Reg d, Imm<8> imm8);
+    bool thumb32_ADR_t3(Imm<1> imm1, Imm<3> imm3, Reg d, Imm<8> imm8);
     bool thumb32_ADD_imm_2(Imm<1> imm1, Imm<3> imm3, Reg d, Imm<8> imm8);
     bool thumb32_BFC(Imm<3> imm3, Reg d, Imm<2> imm2, Imm<5> msb);
     bool thumb32_BFI(Reg n, Imm<3> imm3, Reg d, Imm<2> imm2, Imm<5> msb);


### PR DESCRIPTION
Now all the plain binary immediate instructions are implemented.