### PR TITLE
backend: x64: block_of_code: Double the total code size.

### DIFF
--- a/src/backend/x64/block_of_code.cpp
+++ b/src/backend/x64/block_of_code.cpp
@@ -43,8 +43,8 @@ const std::array<Xbyak::Reg64, 6> BlockOfCode::ABI_PARAMS = {BlockOfCode::ABI_PA
 
 namespace {
 
-constexpr size_t TOTAL_CODE_SIZE = 128 * 1024 * 1024;
-constexpr size_t FAR_CODE_OFFSET = 100 * 1024 * 1024;
+constexpr size_t TOTAL_CODE_SIZE = 256 * 1024 * 1024;
+constexpr size_t FAR_CODE_OFFSET = 200 * 1024 * 1024;
 constexpr size_t CONSTANT_POOL_SIZE = 2 * 1024 * 1024;
 
 class CustomXbyakAllocator : public Xbyak::Allocator {


### PR DESCRIPTION
- The current limits are being hit in yuzu with some games (e.g. newer updates of BotW and SSBU).
- Increasing this fixes slow-downs in these games due to code being recompiled.

Credit to @degasus for finding this problem.