### PR TITLE
backend/x64: Fix PerfMapRegister usages.

### DIFF
--- a/src/backend/x64/a32_emit_x64.cpp
+++ b/src/backend/x64/a32_emit_x64.cpp
@@ -115,6 +115,9 @@ A32EmitX64::BlockDescriptor A32EmitX64::Emit(IR::Block& block) {
     // Start emitting.
     code.align();
     const u8* const entrypoint = code.getCurr();
+    code.SwitchToFarCode();
+    const u8* const entrypoint_far = code.getCurr();
+    code.SwitchToNearCode();
 
     EmitCondPrelude(ctx);
 
@@ -160,7 +163,7 @@ A32EmitX64::BlockDescriptor A32EmitX64::Emit(IR::Block& block) {
     const auto range = boost::icl::discrete_interval<u32>::closed(descriptor.PC(), end_location.PC() - 1);
     block_ranges.AddRange(range, descriptor);
 
-    return RegisterBlock(descriptor, entrypoint, size);
+    return RegisterBlock(descriptor, entrypoint, entrypoint_far, size);
 }
 
 void A32EmitX64::ClearCache() {

--- a/src/backend/x64/a64_emit_x64.cpp
+++ b/src/backend/x64/a64_emit_x64.cpp
@@ -81,6 +81,9 @@ A64EmitX64::BlockDescriptor A64EmitX64::Emit(IR::Block& block) {
     // Start emitting.
     code.align();
     const u8* const entrypoint = code.getCurr();
+    code.SwitchToFarCode();
+    const u8* const entrypoint_far = code.getCurr();
+    code.SwitchToNearCode();
 
     ASSERT(block.GetCondition() == IR::Cond::AL);
 
@@ -126,7 +129,7 @@ A64EmitX64::BlockDescriptor A64EmitX64::Emit(IR::Block& block) {
     const auto range = boost::icl::discrete_interval<u64>::closed(descriptor.PC(), end_location.PC() - 1);
     block_ranges.AddRange(range, descriptor);
 
-    return RegisterBlock(descriptor, entrypoint, size);
+    return RegisterBlock(descriptor, entrypoint, entrypoint_far, size);
 }
 
 void A64EmitX64::ClearCache() {
@@ -358,6 +361,7 @@ void A64EmitX64::GenTerminalHandlers() {
         code.and_(code.ABI_PARAM1.cvt32(), fast_dispatch_table_mask);
         code.lea(code.ABI_RETURN, code.ptr[code.ABI_PARAM1 + code.ABI_PARAM2]);
         code.ret();
+        PerfMapRegister(fast_dispatch_table_lookup, code.getCurr(), "a64_fast_dispatch_table_lookup");
     }
 }
 

--- a/src/backend/x64/emit_x64.cpp
+++ b/src/backend/x64/emit_x64.cpp
@@ -264,8 +264,11 @@ Xbyak::Label EmitX64::EmitCond(IR::Cond cond) {
     return pass;
 }
 
-EmitX64::BlockDescriptor EmitX64::RegisterBlock(const IR::LocationDescriptor& descriptor, CodePtr entrypoint, size_t size) {
+EmitX64::BlockDescriptor EmitX64::RegisterBlock(const IR::LocationDescriptor& descriptor, CodePtr entrypoint, CodePtr entrypoint_far, size_t size) {
     PerfMapRegister(entrypoint, code.getCurr(), LocationDescriptorToFriendlyName(descriptor));
+    code.SwitchToFarCode();
+    PerfMapRegister(entrypoint_far, code.getCurr(), LocationDescriptorToFriendlyName(descriptor) + "_far");
+    code.SwitchToNearCode();
     Patch(descriptor, entrypoint);
 
     BlockDescriptor block_desc{entrypoint, size};

--- a/src/backend/x64/emit_x64.h
+++ b/src/backend/x64/emit_x64.h
@@ -94,7 +94,7 @@ protected:
     virtual std::string LocationDescriptorToFriendlyName(const IR::LocationDescriptor&) const = 0;
     void EmitAddCycles(size_t cycles);
     Xbyak::Label EmitCond(IR::Cond cond);
-    BlockDescriptor RegisterBlock(const IR::LocationDescriptor& location_descriptor, CodePtr entrypoint, size_t size);
+    BlockDescriptor RegisterBlock(const IR::LocationDescriptor& location_descriptor, CodePtr entrypoint, CodePtr entrypoint_far, size_t size);
     void PushRSBHelper(Xbyak::Reg64 loc_desc_reg, Xbyak::Reg64 index_reg, IR::LocationDescriptor target);
 
     // Terminal instruction emitters

--- a/src/backend/x64/perf_map.cpp
+++ b/src/backend/x64/perf_map.cpp
@@ -47,6 +47,11 @@ void OpenFile() {
 
 namespace detail {
 void PerfMapRegister(const void* start, const void* end, std::string_view friendly_name) {
+    if (start == end) {
+        // Nothing to register
+        return;
+    }
+
     std::lock_guard guard{mutex};
 
     if (!file) {


### PR DESCRIPTION
Both the far code and fast_dispatch_table_lookup were missing.

TODO: BlockOfCode::ClearCache also clears the perf file, however the trampolines are not generates. This leads to missing registered code.