### PR TITLE
a64_emit_x64: Implement fastmem for A64 frontend for 8-64 bit reads/writes

### DIFF
--- a/src/dynarmic/backend/x64/a32_emit_x64.h
+++ b/src/dynarmic/backend/x64/a32_emit_x64.h
@@ -106,9 +106,9 @@ protected:
 
     // Memory access helpers
     template<std::size_t bitsize, auto callback>
-    void ReadMemory(A32EmitContext& ctx, IR::Inst* inst);
+    void EmitMemoryRead(A32EmitContext& ctx, IR::Inst* inst);
     template<std::size_t bitsize, auto callback>
-    void WriteMemory(A32EmitContext& ctx, IR::Inst* inst);
+    void EmitMemoryWrite(A32EmitContext& ctx, IR::Inst* inst);
     template<std::size_t bitsize, auto callback>
     void ExclusiveReadMemory(A32EmitContext& ctx, IR::Inst* inst);
     template<std::size_t bitsize, auto callback>

--- a/src/dynarmic/backend/x64/a64_interface.cpp
+++ b/src/dynarmic/backend/x64/a64_interface.cpp
@@ -38,6 +38,9 @@ static std::function<void(BlockOfCode&)> GenRCP(const A64::UserConfig& conf) {
         if (conf.page_table) {
             code.mov(code.r14, Common::BitCast<u64>(conf.page_table));
         }
+        if (conf.fastmem_pointer) {
+            code.mov(code.r13, Common::BitCast<u64>(conf.fastmem_pointer));
+        }
     };
 }
 

--- a/src/dynarmic/interface/A32/config.h
+++ b/src/dynarmic/interface/A32/config.h
@@ -173,6 +173,8 @@ struct UserConfig {
     void* fastmem_pointer = nullptr;
     /// Determines if instructions that pagefault should cause recompilation of that block
     /// with fastmem disabled.
+    /// Recompiled code will use the page_table if this is available, otherwise memory
+    /// accesses will hit the memory callbacks.
     bool recompile_on_fastmem_failure = true;
 
     // Coprocessors

--- a/src/dynarmic/interface/A64/config.h
+++ b/src/dynarmic/interface/A64/config.h
@@ -202,7 +202,7 @@ struct UserConfig {
     void** page_table = nullptr;
     /// Declares how many valid address bits are there in virtual addresses.
     /// Determines the size of page_table. Valid values are between 12 and 64 inclusive.
-    /// This is only used if page_table is not nullptr.
+    /// This is only used if page_table or fastmem_pointer is not nullptr.
     size_t page_table_address_space_bits = 36;
     /// Masks out the first N bits in host pointers from the page table.
     /// The intention behind this is to allow users of Dynarmic to pack attributes in the
@@ -213,7 +213,7 @@ struct UserConfig {
     /// page table. If true, Dynarmic will silently mirror page_table's address space. If
     /// false, accessing memory outside of page_table bounds will result in a call to the
     /// relevant memory callback.
-    /// This is only used if page_table is not nullptr.
+    /// This is only used if page_table or fastmem_pointer is not nullptr.
     bool silently_mirror_page_table = true;
     /// Determines if the pointer in the page_table shall be offseted locally or globally.
     /// 'false' will access page_table[addr >> bits][addr & mask]
@@ -231,6 +231,18 @@ struct UserConfig {
     /// Determines if the above option only triggers when the misalignment straddles a
     /// page boundary.
     bool only_detect_misalignment_via_page_table_on_page_boundary = false;
+
+    /// Fastmem Pointer
+    /// This should point to the beginning of a 2^page_table_address_space_bits bytes
+    /// address space which is in arranged just like what you wish for emulated memory to
+    /// be. If the host page faults on an address, the JIT will fallback to calling the
+    /// MemoryRead*/MemoryWrite* callbacks.
+    void* fastmem_pointer = nullptr;
+    /// Determines if instructions that pagefault should cause recompilation of that block
+    /// with fastmem disabled.
+    /// Recompiled code will use the page_table if this is available, otherwise memory
+    /// accesses will hit the memory callbacks.
+    bool recompile_on_fastmem_failure = true;
 
     /// This option relates to translation. Generally when we run into an unpredictable
     /// instruction the ExceptionRaised callback is called. If this is true, we define

--- a/tests/A64/a64.cpp
+++ b/tests/A64/a64.cpp
@@ -775,3 +775,46 @@ TEST_CASE("A64: Cache Maintenance Instructions", "[a64]") {
     env.ticks_left = 3;
     jit.Run();
 }
+
+TEST_CASE("A64: Memory access (fastmem)", "[a64]") {
+    constexpr size_t address_width = 12;
+    constexpr size_t memory_size = 1ull << address_width; // 4K
+    constexpr size_t page_size = 4 * 1024;
+    constexpr size_t buffer_size = 2 * page_size;
+    char buffer[buffer_size];
+
+    void* buffer_ptr = reinterpret_cast<void*>(buffer);
+    size_t buffer_size_nconst = buffer_size;
+    char* backing_memory = reinterpret_cast<char*>(std::align(page_size, memory_size, buffer_ptr, buffer_size_nconst));
+
+    A64FastmemTestEnv env{backing_memory};
+    Dynarmic::A64::UserConfig config{&env};
+    config.fastmem_pointer = backing_memory;
+    config.page_table_address_space_bits = address_width;
+    config.recompile_on_fastmem_failure = false;
+    config.silently_mirror_page_table = true;
+    config.processor_id = 0;
+
+    Dynarmic::A64::Jit jit{config};
+    memset(backing_memory, 0, memory_size);
+    memcpy(backing_memory + 0x100, "Lorem ipsum dolor sit amet, consectetur adipiscing elit.", 57);
+
+    env.MemoryWrite32(0, 0xA9401404); // LDP X4, X5, [X0]
+    env.MemoryWrite32(4, 0xF9400046); // LDR X6, [X2]
+    env.MemoryWrite32(8, 0xA9001424); // STP X4, X5, [X1]
+    env.MemoryWrite32(12, 0xF9000066); // STR X6, [X3]
+    env.MemoryWrite32(16, 0x14000000); // B .
+    jit.SetRegister(0, 0x100);
+    jit.SetRegister(1, 0x1F0);
+    jit.SetRegister(2, 0x10F);
+    jit.SetRegister(3, 0x1FF);
+
+    jit.SetPC(0);
+    jit.SetSP(memory_size - 1);
+    jit.SetFpsr(0x03480000);
+    jit.SetPstate(0x30000000);
+    env.ticks_left = 5;
+
+    jit.Run();
+    REQUIRE(strncmp(backing_memory + 0x100, backing_memory + 0x1F0, 23) == 0);
+}


### PR DESCRIPTION
This is a rebase of the fm branch. I've moved small hotfixes from the second commit to the first commit.

I've tested it a lot on yuzu, and it roughly provides a 15% speed over the page table approach.

@MerryMage Do you want to have this feature in master?