### PR TITLE
fixup! a64/fastmem: Implement fastmem on 128 bit memory access.

### DIFF
--- a/src/dynarmic/backend/x64/a64_emit_x64.cpp
+++ b/src/dynarmic/backend/x64/a64_emit_x64.cpp
@@ -1120,6 +1120,7 @@ void A64EmitX64::EmitA64ReadMemory128(A64EmitContext& ctx, IR::Inst* inst) {
         // Use page table
         ASSERT(conf.page_table);
         const auto src_ptr = EmitVAddrLookup(code, ctx, 128, abort, vaddr);
+        require_abort_handling = true;
         code.movups(value, xword[src_ptr]);
     }
     code.L(end);


### PR DESCRIPTION
Sorry sorry sorry. Seems like I've just tested fastmem. Stupid copy&paste error.